### PR TITLE
Always Use Proxy for Downloading Images

### DIFF
--- a/zoommanager.js
+++ b/zoommanager.js
@@ -259,6 +259,11 @@ Request a tile from the server
 @param {Number} [n=0] - Number of time the tile has already been requested
 */
 ZoomManager.addTile = function addTile(url, x, y, ntries) {
+	//add proxy URL
+	var PHPSCRIPT = ZoomManager.proxy_url;
+	var codedurl=encodeURIComponent(url);
+	url = PHPSCRIPT + "?url=" + codedurl;
+	
 	//Request a tile from the server and display it once it loaded
 	ntries = ntries | 0; // Number of time the tile has already been requested
 	var img = new Image;


### PR DESCRIPTION
For the longest time, I couldn't figure out why I couldn't save the Image. I tried to convert the canvas to a PNG via Javascript, when it told me that the canvas was tainted. I realized that we are calling the images from the original location, and hence the canvas gets tainted. So I put in this code to always use the proxy for downloading the Images.

I think having that as default is a much better option. Please consider merging it in master.