### PR TITLE
remove ?> from php files

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,3 +1,2 @@
 <?php
 header("Location: dezoomify.html");
-?>

--- a/proxy.php
+++ b/proxy.php
@@ -45,4 +45,4 @@ if (false !== ($f = fopen($url, 'r', false, $context))) {
 } else {
   http_response_code(500);
 }
-?>
+


### PR DESCRIPTION
Per PSR-2, it's [recommended not to use closing tags in pure PHP files](http://www.php-fig.org/psr/psr-2/#22-files), as they are not needed, and whitespace characters after them can inadvertently be sent down to the client:

https://stackoverflow.com/a/24212983/270302
