### PR TITLE
Node app: Update JSDOM

### DIFF
--- a/node-app/dezoomify-node.js
+++ b/node-app/dezoomify-node.js
@@ -1,5 +1,5 @@
 "use strict";
-var jsdom = require("jsdom");
+var jsdom = require("jsdom/lib/old-api.js");
 var Canvas = require("canvas");
 var request = require("request");
 var fs = require("fs");

--- a/node-app/package.json
+++ b/node-app/package.json
@@ -5,7 +5,7 @@
   "main": "dezoomify-node.js",
   "dependencies": {
     "canvas": "^1.4.0",
-    "jsdom": "^8.4.0",
+    "jsdom": "^11.9.0",
     "request": "^2.72.0"
   },
   "devDependencies": {},
@@ -24,7 +24,7 @@
     "download"
   ],
   "author": "Ophir LOJKINE",
-  "license": "GPL",
+  "license": "GPL-2.0",
   "bugs": {
     "url": "https://github.com/lovasoa/dezoomify/issues"
   },


### PR DESCRIPTION
This updates the version of JSDOM and fixes the 'license should be a valid SPDX license expression' error on installation.