### PR TITLE
Implement dezoomer for Visual Library Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following formats are supported by dezoomify:
  * [krpano Panorama Viewer](http://krpano.com), mainly used in panoramic images and interactive virtual tours.
  * [The Tretiakov gallery](http://www.tretyakovgallery.ru/en/), official website of the Третьяковская галерея (in Moscow).
  * [FSI Viewer](https://www.neptunelabs.com/products/fsi-viewer/), zoomable image server by NeptuneLabs GmbH.
+ * [Visual Library Server](https://www.semantics.de/visual_library/), by semantics
 
 Dezoomify also has a
 [generic dezoomer](https://github.com/lovasoa/dezoomify/wiki/Dezoomify-FAQ#the-page-uses-an-image-viewer-that-is-not-supported-by-dezoomify-is-there-still-a-chance-).

--- a/dezoomers/vls.js
+++ b/dezoomers/vls.js
@@ -1,0 +1,50 @@
+var vls = (function() {
+  return {
+    name: 'VLS',
+    description: 'Visual Library Server, by semantics',
+    urls: [
+      /\/(thumbview|pageview|zoom)\/\d+$/
+    ],
+    contents: [],
+    findFile: function getInfoFile (baseUrl, callback) {
+      var url = baseUrl.replace(/\/(thumbview|pageview|zoom)\//, '/zoom/');
+      callback(url);
+    },
+    open: function (url) {
+      ZoomManager.getFile(url, {type: 'xml'}, function (doc, xhr) {
+        var vars = {};
+        var varNodes = doc.getElementsByTagName('var');
+        for (var i = 0; i < varNodes.length; i++) {
+          vars[varNodes[i].getAttribute('id')] = varNodes[i].getAttribute('value');
+        }
+        var mapNode = doc.getElementById('map');
+
+        var id = mapNode ? mapNode.getAttribute('vls:ot_id') : null;
+        if (!id) {
+          throw new Error('Unable to extract image ID');
+        }
+        var rotate = mapNode.getAttribute('vls:flip_rotate');
+        var width = parseInt(mapNode.getAttribute('vls:width'));
+        var height = parseInt(mapNode.getAttribute('vls:height'));
+        var zoomLevels = mapNode.getAttribute('vls:zoomsizes').split(',');
+        var path = ['/image/tile/wc', rotate, width, '1.0.0', id, zoomLevels.length - 1].join('/');
+        var tileSize = parseInt(vars['zoomTileSize']);
+
+        // Workaround: avoid cropping at the bottom
+        height = (Math.floor((height - 1) / tileSize) + 1) * tileSize;
+
+        ZoomManager.readyToRender({
+          origin: url,
+          path: path,
+          width: width,
+          height: height,
+          tileSize: tileSize,
+        });
+      });
+    },
+    getTileURL: function (x, y, zoom, data) {
+      return [data.path, x, (data.nbrTilesY - y - 1) + '.jpg'].join('/');
+    },
+  };
+})();
+ZoomManager.addDezoomer(vls);

--- a/dezoomify.html
+++ b/dezoomify.html
@@ -123,6 +123,7 @@
 <script type="text/javascript" src="dezoomers/iiif.js" ></script>
 <script type="text/javascript" src="dezoomers/fsi.js" ></script>
 <script type="text/javascript" src="dezoomers/tretiakov.js" ></script>
+<script type="text/javascript" src="dezoomers/vls.js" ></script>
 <script type="text/javascript" src="dezoomers/generic.js" ></script>
 <script type="text/javascript" src="browser-init.js"></script>
 

--- a/tests/test_urls.js
+++ b/tests/test_urls.js
@@ -90,5 +90,9 @@ var test_urls = [
   {
     "name": "FSI",
     "url": "http://romandelarose.org/#read;Douce332.140r.tif"
+  },
+  {
+    "name": "VLS",
+    "url": "https://www.e-rara.ch/bau_1/ch17/content/pageview/4243948"
   }
 ];


### PR DESCRIPTION
Some instances of Visual Library Server do have support for IIIF. However not all institutions enable the service. In those cases, this dezoomer will be able to dezoom the image nonetheless.

Example: https://www.e-rara.ch/bau_1/ch17/content/pageview/4243948