### PR TITLE
Update node app for Canvas 2.1

### DIFF
--- a/node-app/dezoomify-node.js
+++ b/node-app/dezoomify-node.js
@@ -31,7 +31,7 @@ function onload(window) {
     console.log(parseInt(progress) + "% : " + text);
   }
   UI.setupRendering = function (data) {
-  	UI.canvas = new Canvas(data.width, data.height);
+  	UI.canvas = new Canvas.Canvas(data.width, data.height);
   	UI.ctx = UI.canvas.getContext("2d");
   };
   ZoomManager.addTile = function addTile (url, x, y, nTries) {

--- a/node-app/package.json
+++ b/node-app/package.json
@@ -4,9 +4,8 @@
   "description": "Download images in various zoomable image formats.",
   "main": "dezoomify-node.js",
   "dependencies": {
-    "canvas": "^1.4.0",
-    "jsdom": "^11.9.0",
-    "request": "^2.72.0"
+    "canvas": "^2.1.0",
+    "jsdom": "^11.12.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This brings the Node app up to the latest version of Canvas, as well as the last version of JSDOM that supports the old API (unsupported from version 12 onwards).