### PR TITLE
iiif: request explicit tile heights

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The most prominent supported websites with live compatibility tests include :
 - Czech Digital Library (api.ceskadigitalniknihovna.cz)
 - National Gallery (nationalgallery.org.uk)
 - National Gallery of Victoria (ngv.vic.gov.au)
+- CSNTM manuscripts (collections.csntm.org)
 - National Library of Australia (nla.gov.au)
 - National Library of Israel (nli.org.il)
 - National Library of Scotland (nls.uk)

--- a/dezoomers/iiif.js
+++ b/dezoomers/iiif.js
@@ -114,7 +114,8 @@ var iiif = (function () {
 
   function getTileURL(x, y, zoom, data) {
     var s = data.tileSize,
-      pxX = x * s, pxY = y * s;
+      pxX = x * s, pxY = y * s,
+      sx, sy;
     //The image size is adjusted for edges
     //width
     if (pxX + s > data.width) {
@@ -134,7 +135,7 @@ var iiif = (function () {
       sx + "," + // source image width
       sy + "/" + // source image height
       sx + "," + // returned image width
-      "" + "/" + // returned image height
+      sy + "/" + // returned image height
       "0" + "/" + //rotation
       data.quality + "." + //quality
       data.format; //format

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -122,7 +122,7 @@ test.describe("dezoomer fixture coverage", () => {
       {
         dezoomer: "IIIF",
         url: "https://fixtures.test/iiif-v2/info.json",
-        expectedTile: "/iiif/v2/256,256,256,256/256,/0/native.png",
+        expectedTile: "/iiif/v2/256,256,256,256/256,256/0/native.png",
       },
       {
         dezoomer: "IIPImage",
@@ -208,7 +208,31 @@ test.describe("dezoomer fixture coverage", () => {
     expect(result.data.origin).toBe("http://127.0.0.1:9877/iiif/v3");
     expect(result.data.quality).toBe("default");
     expect(result.data.format).toBe("jpg");
-    expect(result.tiles.at(-1).url).toContain("/iiif/v3/256,256,256,256/256,/0/default.jpg");
+    expect(result.tiles.at(-1).url).toContain("/iiif/v3/256,256,256,256/256,256/0/default.jpg");
+  });
+
+  test("generates IIIF tile URLs with explicit returned dimensions", async ({ page }) => {
+    const urls = await page.evaluate(() => {
+      const iiif = window.ZoomManager.dezoomersList.IIIF;
+      const data = {
+        origin: "https://iiif.example/image",
+        width: 600,
+        height: 384,
+        tileSize: 256,
+        quality: "default",
+        format: "jpg",
+      };
+
+      return [
+        iiif.getTileURL(0, 0, 1, data),
+        iiif.getTileURL(1, 1, 1, data),
+      ];
+    });
+
+    expect(urls).toEqual([
+      "https://iiif.example/image/0,0,256,256/256,256/0/default.jpg",
+      "https://iiif.example/image/256,256,256,128/256,128/0/default.jpg",
+    ]);
   });
 
   test("keeps Zoomify full-resolution-only NUMTILES in TileGroup0", async ({ page }) => {
@@ -236,7 +260,7 @@ test.describe("dezoomer fixture coverage", () => {
       "http://127.0.0.1:9877/server.iip?IIIF=/fronts/N-6660-00-000003-FS-PYR.tif"
     );
     expect(result.tiles.at(-1).url).toContain(
-      "/server.iip?IIIF=/fronts/N-6660-00-000003-FS-PYR.tif/256,256,256,256/256,/0/default.jpg"
+      "/server.iip?IIIF=/fronts/N-6660-00-000003-FS-PYR.tif/256,256,256,256/256,256/0/default.jpg"
     );
   });
 

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -22,6 +22,11 @@ const targets = [
     url: "https://api.ceskadigitalniknihovna.cz/search/api/client/v7.0/items/cuni/uuid:425e338e-9420-11ec-ac48-fa163e4ea95f/image/zoomify/ImageProperties.xml",
   },
   {
+    name: "CSNTM manuscripts",
+    expectedDezoomer: "IIIF",
+    url: "https://collections.csntm.org/image-service/iiif/MNTGRCGA01/default/M_NT_GRC_GA01_20250609_203r/M_NT_GRC_GA01_20250609_203r/info.json",
+  },
+  {
     name: "Memorix TopViewer",
     expectedDezoomer: "TopViewer",
     url: "https://images.memorix.nl/wba/topviewjson/memorix/6eb5a89b-b76c-5039-3999-aabfd7a0c7c9",


### PR DESCRIPTION
## Summary

- Request IIIF tiles with explicit returned width and height instead of the width-only shorthand.
- Add deterministic coverage for square tiles and edge tiles with a shorter returned height.

## Known site

This unblocks zoomable images on collections.csntm.org, whose IIIF server rejects size segments like `1024,` but accepts `1024,1024`.

Closes #916

## Tests

- `cd /private/tmp/dezoomify-iiif-explicit-height/tests && npm test`