### PR TITLE
iiif: ignore internal manifest ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following formats are supported by dezoomify:
 The most prominent supported websites with live compatibility tests include :
 - Arts & Culture (artsandculture.google.com)
 - Czech Digital Library (api.ceskadigitalniknihovna.cz)
+- Memoire des hommes (memoiredeshommes.defense.gouv.fr)
 - National Gallery (nationalgallery.org.uk)
 - National Gallery of Victoria (ngv.vic.gov.au)
 - CSNTM manuscripts (collections.csntm.org)

--- a/dezoomers/iiif.js
+++ b/dezoomers/iiif.js
@@ -25,6 +25,19 @@ var iiif = (function () {
     result = result.replace('micrio.vangoghmuseum.nl/iiif', 'micrio-cdn.vangoghmuseum.nl');
     return result;
   }
+
+  function isPrivateIPv4(hostname) {
+    var match = hostname.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+    if (!match) return false;
+    var first = Number(match[1]);
+    var second = Number(match[2]);
+    return (
+      first === 10 ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168)
+    );
+  }
+
   return {
     "name": "IIIF",
     "description": "International Image Interoperability Framework",
@@ -81,7 +94,7 @@ var iiif = (function () {
           // See https://github.com/lovasoa/dezoomify/issues/582
           data["@id"] = data["@id"].replace(/^https?, (https?:\/\/)/, '$1');
           var origin = new URL(data["@id"], url);
-          if (origin.hostname === "localhost" || origin.hostname === "example.com") {
+          if (origin.hostname === "localhost" || origin.hostname === "example.com" || isPrivateIPv4(origin.hostname)) {
             throw new Error("probably a test host");
           }
         } catch (e) {

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -252,6 +252,17 @@ test.describe("dezoomer fixture coverage", () => {
     );
   });
 
+  test("ignores internal IIIF ids and uses the public info.json base", async ({ page }) => {
+    const result = await runDezoomer(page, "Select automatically", "/fixtures/iiif-private-id/info.json");
+
+    expect(result.dezoomerName).toBe("IIIF");
+    expect(result.data.origin).toBe("http://127.0.0.1:9877/fixtures/iiif-private-id");
+    expect(result.tiles.at(-1).url).toContain(
+      "/fixtures/iiif-private-id/256,256,256,256/256,256/0/native.png"
+    );
+    expect(result.tiles.at(-1).url).not.toContain("10.0.0.42");
+  });
+
   test("extracts current National Gallery IIIF URLs from pages", async ({ page }) => {
     const result = await runDezoomer(page, "Select automatically", "https://fixtures.test/national-gallery");
 

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -111,6 +111,21 @@ function fixtureFor(target, origin) {
     });
   }
 
+  if (
+    href === "https://fixtures.test/iiif-private-id/info.json" ||
+    href === `${origin}/fixtures/iiif-private-id/info.json`
+  ) {
+    return json({
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": "http://10.0.0.42/iiif/private-id",
+      width: 512,
+      height: 512,
+      tiles: [{ width: 256, height: 256, scaleFactors: [1, 2] }],
+      qualities: ["native"],
+      formats: ["png"],
+    });
+  }
+
   if (href === "https://fixtures.test/national-gallery") {
     return html(`
       <img src="/server.iip?IIIF=/fronts/N-6660-00-000003-FS-PYR.tif/full/!80,50/0/default.jpg">
@@ -280,6 +295,13 @@ function serveStatic(req, res, pathname) {
     return;
   }
 
+  if (pathname === "/fixtures/iiif-private-id/info.json") {
+    const fixture = fixtureFor("https://fixtures.test/iiif-private-id/info.json", origin);
+    res.writeHead(fixture.status, fixture.headers);
+    res.end(fixture.body);
+    return;
+  }
+
   if (pathname === "/entity/OBJECT/1") {
     const fixture = fixtureFor("https://fixtures.test/entity/OBJECT/1", origin);
     res.writeHead(fixture.status, fixture.headers);
@@ -297,6 +319,7 @@ function serveStatic(req, res, pathname) {
   if (
     pathname === "/fixtures/tile.jpg" ||
     pathname === "/fixtures/pnav/image.jpg" ||
+    pathname.startsWith("/fixtures/iiif-private-id/") ||
     pathname.startsWith("/iiif/") ||
     pathname === "/server.iip"
   ) {

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -12,6 +12,11 @@ const targets = [
     url: "https://www.nationalgallery.org.uk/paintings/alexandre-calame-at-handeck",
   },
   {
+    name: "Memoire des hommes",
+    expectedDezoomer: "IIIF",
+    url: "https://www.memoiredeshommes.defense.gouv.fr/_recherche-images/show/112145/image/56545/0/info.json",
+  },
+  {
     name: "National Gallery of Victoria",
     expectedDezoomer: "Zoomify",
     url: "https://www.ngv.vic.gov.au/explore/collection/work/3867/",


### PR DESCRIPTION
## Summary

- Ignore IIIF manifest `@id`/`id` values that point to private IPv4 hosts.
- Fall back to the public `info.json` base so tile URLs stay reachable.
- Add deterministic coverage for an internal `10.x.x.x` IIIF id.
- List Memoire des hommes in the live compatibility docs and targets.

This unblocks IIIF images on memoiredeshommes.defense.gouv.fr where the public `info.json` advertises an internal host.

Closes #870

## Tests

- `cd /private/tmp/dezoomify-iiif-internal-id/tests && npm test`
- `cd /private/tmp/dezoomify-iiif-internal-id/tests && npm run test:live -- --grep "Memoire des hommes"`