### PR TITLE
iiif: normalize default port metadata origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The most prominent supported websites with live compatibility tests include :
 - National Library of Israel (nli.org.il)
 - National Library of Scotland (nls.uk)
 - Academia Sinica Bronze Rubbings (bronze.asdc.sinica.edu.tw)
+- Westchester County Archives (collections.westchestergov.com)
 - Bibliotheques specialisees de Paris (bibliotheques-specialisees.paris.fr)
 - FSI Viewer examples (neptunelabs.com)
 - krpano examples (krpano.com)

--- a/dezoomers/iiif.js
+++ b/dezoomers/iiif.js
@@ -71,6 +71,18 @@ var iiif = (function () {
           var array = (array && array.length) ? array : [defaultValue];
           return ~array.indexOf(search) ? search : array[0];
         }
+        function explicitPort(rawUrl) {
+          var match = String(rawUrl).match(/^https?:\/\/(?:\[[^\]]+\]|[^\/?#:]+):(\d+)(?:[\/?#]|$)/i);
+          return match && match[1];
+        }
+        function hasDefaultPortOriginMismatch(serviceUrl, infoUrl, rawServiceUrl) {
+          if (serviceUrl.hostname !== infoUrl.hostname) return false;
+          if (serviceUrl.protocol === infoUrl.protocol && serviceUrl.port === infoUrl.port) return false;
+
+          var port = explicitPort(rawServiceUrl);
+          return port === "80" || port === "443" ||
+            (serviceUrl.protocol === "http:" && infoUrl.protocol === "https:" && !serviceUrl.port);
+        }
 
         var tiles;
         if (data.tiles && data.tiles.length) {
@@ -94,6 +106,11 @@ var iiif = (function () {
           // See https://github.com/lovasoa/dezoomify/issues/582
           data["@id"] = data["@id"].replace(/^https?, (https?:\/\/)/, '$1');
           var origin = new URL(data["@id"], url);
+          var infoUrl = new URL(url);
+          if (hasDefaultPortOriginMismatch(origin, infoUrl, data["@id"])) {
+            origin.protocol = infoUrl.protocol;
+            origin.host = infoUrl.host;
+          }
           if (origin.hostname === "localhost" || origin.hostname === "example.com" || isPrivateIPv4(origin.hostname)) {
             throw new Error("probably a test host");
           }

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -263,6 +263,17 @@ test.describe("dezoomer fixture coverage", () => {
     expect(result.tiles.at(-1).url).not.toContain("10.0.0.42");
   });
 
+  test("uses the info.json origin when IIIF metadata has a same-host default port", async ({ page }) => {
+    const result = await runDezoomer(page, "IIIF", "/fixtures/iiif-default-port/info.json");
+
+    expect(result.dezoomerName).toBe("IIIF");
+    expect(result.data.origin).toBe("http://127.0.0.1:9877/iiif/default-port");
+    expect(result.tiles.at(-1).url).toContain(
+      "http://127.0.0.1:9877/iiif/default-port/256,256,256,256/256,256/0/native.jpg"
+    );
+    expect(result.tiles.at(-1).url).not.toContain(":80/");
+  });
+
   test("extracts current National Gallery IIIF URLs from pages", async ({ page }) => {
     const result = await runDezoomer(page, "Select automatically", "https://fixtures.test/national-gallery");
 

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -126,6 +126,18 @@ function fixtureFor(target, origin) {
     });
   }
 
+  if (href === `${origin}/fixtures/iiif-default-port/info.json`) {
+    return json({
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": `http://${host}:80/iiif/default-port`,
+      width: 512,
+      height: 512,
+      tiles: [{ width: 256, height: 256, scaleFactors: [1, 2] }],
+      qualities: ["native"],
+      formats: ["jpg"],
+    });
+  }
+
   if (href === "https://fixtures.test/national-gallery") {
     return html(`
       <img src="/server.iip?IIIF=/fronts/N-6660-00-000003-FS-PYR.tif/full/!80,50/0/default.jpg">
@@ -297,6 +309,13 @@ function serveStatic(req, res, pathname) {
 
   if (pathname === "/fixtures/iiif-private-id/info.json") {
     const fixture = fixtureFor("https://fixtures.test/iiif-private-id/info.json", origin);
+    res.writeHead(fixture.status, fixture.headers);
+    res.end(fixture.body);
+    return;
+  }
+
+  if (pathname === "/fixtures/iiif-default-port/info.json") {
+    const fixture = fixtureFor(`${origin}/fixtures/iiif-default-port/info.json`, origin);
     res.writeHead(fixture.status, fixture.headers);
     res.end(fixture.body);
     return;

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -82,6 +82,11 @@ const targets = [
     url: "https://map-view.nls.uk/iiif/19619%2F196194600/info.json",
   },
   {
+    name: "Westchester County Archives",
+    expectedDezoomer: "IIIF",
+    url: "https://collections.westchestergov.com/digital/collection/ccmaps/id/69/",
+  },
+  {
     name: "pnav catalog.shm.ru",
     expectedDezoomer: "pnav",
     url: "https://catalog.shm.ru/entity/OBJECT/2117418",


### PR DESCRIPTION
## Summary
- Normalize IIIF service origins when metadata advertises the same hostname with a default-port/protocol mismatch, so generated tile URLs use the reachable info.json origin.
- Add deterministic coverage and live compatibility listing for the failure class that blocks zoomable images on collections.westchestergov.com.

Closes #865

## Tests
- cd tests && npm test
- cd tests && npm run test:live -- -g "Westchester County Archives"