### PR TITLE
seadragon: extract legacy embed metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The most prominent supported websites with live compatibility tests include :
 - National Library of Australia (nla.gov.au)
 - National Library of Israel (nli.org.il)
 - National Library of Scotland (nls.uk)
+- Academia Sinica Bronze Rubbings (bronze.asdc.sinica.edu.tw)
 - Bibliotheques specialisees de Paris (bibliotheques-specialisees.paris.fr)
 - FSI Viewer examples (neptunelabs.com)
 - krpano examples (krpano.com)

--- a/dezoomers/seadragon.js
+++ b/dezoomers/seadragon.js
@@ -13,6 +13,7 @@ var seadragon = (function () { //Code isolation
 		],
 		"contents": [
 			/dziUrlTemplate/,
+			/Seadragon\.embed\([^)]*["'][^"']+\.(?:xml|dzi)(?:\?[^"']*)?["']/i,
 			/[^"'()<>]+\.(?:dzi)/i,
 			/schemas\.microsoft\.com\/deepzoom/,
 			/zoom(?:\.it|hub.net)\/.*\.js/,
@@ -90,6 +91,9 @@ var seadragon = (function () { //Code isolation
 					var url = m[1].replace("{group}", group).replace("{index}", index);
 					return callback(url);
 				}
+
+				var seadragonEmbedMatch = text.match(/Seadragon\.embed\([^)]*["']([^"']+\.(?:xml|dzi)(?:\?[^"']*)?)["'][^)]*\)/i);
+				if (seadragonEmbedMatch) return callback(seadragonEmbedMatch[1]);
 
 				// Any url ending with .xml or .dzi
 				var matchPath = text.match(/[^"'()<>]+\.(?:xml|dzi)/i);

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -115,6 +115,11 @@ test.describe("dezoomer fixture coverage", () => {
         expectedTile: "https://fixtures.test/deepzoom/sample_files/9/1_1.jpg",
       },
       {
+        dezoomer: "Seadragon (Deep Zoom Image)",
+        url: "https://fixtures.test/deepzoom/legacy-embed.html",
+        expectedTile: "https://fixtures.test/deepzoom/legacy_files/9/1_1.jpg",
+      },
+      {
         dezoomer: "IIIF",
         url: "https://fixtures.test/iiif-v2/info.json",
         expectedTile: "/iiif/v2/256,256,256,256/256,/0/native.png",

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -64,6 +64,22 @@ function fixtureFor(target, origin) {
     );
   }
 
+  if (href === "https://fixtures.test/deepzoom/legacy-embed.html") {
+    return html(`
+      <div id="auto"></div>
+      <script src="/seadragon-min.js"></script>
+      <script>
+        Seadragon.embed("auto", "600px", "legacy.xml");
+      </script>
+    `);
+  }
+
+  if (href === "https://fixtures.test/deepzoom/legacy.xml") {
+    return xml(
+      '<Image TileSize="256" Overlap="0" Format="jpg" xmlns="http://schemas.microsoft.com/deepzoom/2008"><Size Width="512" Height="512" /></Image>'
+    );
+  }
+
   if (href === "https://fixtures.test/iiif-v2/info.json") {
     return json({
       "@context": "http://iiif.io/api/image/2/context.json",

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -37,6 +37,11 @@ const targets = [
     url: "https://nla.gov.au/nla.obj-152644715/view",
   },
   {
+    name: "Academia Sinica Bronze Rubbings",
+    expectedDezoomer: "Seadragon (Deep Zoom Image)",
+    url: "https://bronze.asdc.sinica.edu.tw/filePool/R/05395-1.html",
+  },
+  {
     name: "FSI Viewer",
     expectedDezoomer: "FSI",
     url: "https://www.neptunelabs.com/fsi-viewer/",


### PR DESCRIPTION
## Summary

- Detect legacy `Seadragon.embed(..., "...xml")` pages during automatic discovery.
- Extract the embedded Deep Zoom XML/DZI path before falling back to generic page scanning.
- Add deterministic fixture coverage plus a live compatibility target for `bronze.asdc.sinica.edu.tw`.

This unblocks Academia Sinica Bronze Rubbings pages such as `https://bronze.asdc.sinica.edu.tw/filePool/R/05395-1.html`, where the metadata is already supported by the Seadragon dezoomer but automatic discovery did not find the embedded XML path.

Closes #866

## Tests

- `cd /private/tmp/dezoomify-seadragon-embed/tests && npm test`
- `cd /private/tmp/dezoomify-seadragon-embed/tests && npm run test:live -- --grep "Academia Sinica Bronze Rubbings"`
