### PR TITLE
zoomify: handle full-resolution NUMTILES values

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following formats are supported by dezoomify:
 
 The most prominent supported websites with live compatibility tests include :
 - Arts & Culture (artsandculture.google.com)
+- Czech Digital Library (api.ceskadigitalniknihovna.cz)
 - National Gallery (nationalgallery.org.uk)
 - National Gallery of Victoria (ngv.vic.gov.au)
 - National Library of Australia (nla.gov.au)

--- a/dezoomers/zoomify.js
+++ b/dezoomers/zoomify.js
@@ -117,6 +117,8 @@ var zoomify = (function () { //Code isolation
 				var w = data.width, h = data.height,
 					ntiles = 0,
 					maxZoom = ZoomManager.findMaxZoom(data);
+				var fullResolutionTiles = Math.ceil(w / data.tileSize) * Math.ceil(h / data.tileSize);
+				data.numTilesIsFullResolutionOnly = data.numTiles === fullResolutionTiles;
 				for (var z = 0; z <= maxZoom; z++) {
 					ntiles += Math.ceil(w / data.tileSize) * Math.ceil(h / data.tileSize);
 					w /= 2; h /= 2;
@@ -133,7 +135,9 @@ var zoomify = (function () { //Code isolation
 		},
 		"getTileURL": function (col, row, zoom, data) {
 			var totalTiles = data.nbrTilesX * data.nbrTilesY;
-			var tileGroup = Math.floor((data.numTiles - totalTiles + col + row * data.nbrTilesX) / 256);
+			var tileGroup = data.numTilesIsFullResolutionOnly
+				? 0
+				: Math.floor((data.numTiles - totalTiles + col + row * data.nbrTilesX) / 256);
 			return "TileGroup" + tileGroup + "/" + zoom + "-" + col + "-" + row + ".jpg";
 		}
 	};

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -206,6 +206,23 @@ test.describe("dezoomer fixture coverage", () => {
     expect(result.tiles.at(-1).url).toContain("/iiif/v3/256,256,256,256/256,/0/default.jpg");
   });
 
+  test("keeps Zoomify full-resolution-only NUMTILES in TileGroup0", async ({ page }) => {
+    const result = await runDezoomer(
+      page,
+      "Select automatically",
+      "https://fixtures.test/zoomify-full-numtiles/ImageProperties.xml"
+    );
+
+    expect(result.dezoomerName).toBe("Zoomify");
+    expect(result.data.numTiles).toBe(280);
+    expect(result.data.numTilesIsFullResolutionOnly).toBe(true);
+    expect(result.tiles).toHaveLength(280);
+    expect(result.tiles.every((tile) => tile.url.includes("/TileGroup0/"))).toBe(true);
+    expect(result.tiles.map((tile) => tile.url)).toContain(
+      "https://fixtures.test/zoomify-full-numtiles/TileGroup0/6-16-6.jpg"
+    );
+  });
+
   test("extracts current National Gallery IIIF URLs from pages", async ({ page }) => {
     const result = await runDezoomer(page, "Select automatically", "https://fixtures.test/national-gallery");
 

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -58,6 +58,12 @@ function fixtureFor(target, origin) {
     );
   }
 
+  if (href === "https://fixtures.test/zoomify-full-numtiles/ImageProperties.xml") {
+    return xml(
+      '<IMAGE_PROPERTIES WIDTH="10240" HEIGHT="1792" NUMTILES="280" VERSION="1.8" TILESIZE="256" />'
+    );
+  }
+
   if (href === "https://fixtures.test/deepzoom/sample.dzi") {
     return xml(
       '<Image TileSize="256" Overlap="0" Format="jpg" xmlns="http://schemas.microsoft.com/deepzoom/2008"><Size Width="512" Height="512" /></Image>'

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -17,6 +17,11 @@ const targets = [
     url: "https://www.ngv.vic.gov.au/explore/collection/work/3867/",
   },
   {
+    name: "Czech Digital Library",
+    expectedDezoomer: "Zoomify",
+    url: "https://api.ceskadigitalniknihovna.cz/search/api/client/v7.0/items/cuni/uuid:425e338e-9420-11ec-ac48-fa163e4ea95f/image/zoomify/ImageProperties.xml",
+  },
+  {
     name: "Memorix TopViewer",
     expectedDezoomer: "TopViewer",
     url: "https://images.memorix.nl/wba/topviewjson/memorix/6eb5a89b-b76c-5039-3999-aabfd7a0c7c9",


### PR DESCRIPTION
Summary
- Detect Zoomify metadata where NUMTILES equals the full-resolution tile grid size.
- Keep those generated tile URLs in TileGroup0 instead of switching at tile 256.
- Add api.ceskadigitalniknihovna.cz to the live compatibility list and target set.

Why
api.ceskadigitalniknihovna.cz reports NUMTILES as the full-resolution tile count, which made Dezoomify request TileGroup1/6-16-6.jpg even though the tile exists under TileGroup0.

Tests
- cd tests && npm test
- cd tests && npm run test:live -- -g "Czech Digital Library"

Closes #912