### PR TITLE
zoomify: resolve showImage paths against base href

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The most prominent supported websites with live compatibility tests include :
 - Westchester County Archives (collections.westchestergov.com)
 - Bibliotheques specialisees de Paris (bibliotheques-specialisees.paris.fr)
 - FSI Viewer examples (neptunelabs.com)
+- Geographicus (geographicus.com)
 - krpano examples (krpano.com)
 - Memorix TopViewer sites (images.memorix.nl)
 - OpenSeadragon Zoomify examples (openseadragon.github.io)

--- a/dezoomers/zoomify.js
+++ b/dezoomers/zoomify.js
@@ -31,6 +31,9 @@ var zoomify = (function () { //Code isolation
 			if (tileUrlMatch) return foundZoomifyPath(tileUrlMatch[0]);
 
 			ZoomManager.getFile(baseUrl, { type: "htmltext" }, function (text, xhr) {
+				var pageBaseUrl = baseUrl;
+				var baseMatch = text.match(/<base\s+[^>]*href\s*=\s*["']([^"']*)/i);
+				if (baseMatch) pageBaseUrl = ZoomManager.resolveRelative(baseMatch[1], baseUrl);
 				// for the zoomify flash player, the path is in the zoomifyImagePath
 				// attribute of a tag
 				// In the HTML5 zoomify player, the path is the second argument
@@ -45,13 +48,14 @@ var zoomify = (function () { //Code isolation
 					while ((matchPath = zRegs[z].exec(text)) != null) {
 						for (var i = 1; i < matchPath.length; i++) {
 							var path = matchPath[i];
-							if (path && foundPaths.indexOf(path) === -1) {
-								foundPaths.push(path);
+							var resolvedPath = path && ZoomManager.resolveRelative(path, pageBaseUrl);
+							if (resolvedPath && foundPaths.indexOf(resolvedPath) === -1) {
+								foundPaths.push(resolvedPath);
 							}
 						}
 					}
 				}
-				if (foundPaths.length > 0) return foundPaths.forEach(foundZoomifyPath);
+				if (foundPaths.length > 0) return foundZoomifyPath(foundPaths[0]);
 
 				// Fluid engage zoomify
 				var fluidMatch = text.match(/accessnumber=([^"&\s']+)/i);

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -110,6 +110,11 @@ test.describe("dezoomer fixture coverage", () => {
         expectedTile: "https://fixtures.test/zoomify/TileGroup0/1-1-1.jpg",
       },
       {
+        dezoomer: "Zoomify",
+        url: "https://fixtures.test/zoomify-base-href/product.html",
+        expectedTile: "https://fixtures.test/zoomify-base-href/assets/maps/sample/TileGroup0/1-1-1.jpg",
+      },
+      {
         dezoomer: "Seadragon (Deep Zoom Image)",
         url: "https://fixtures.test/deepzoom/sample.dzi",
         expectedTile: "https://fixtures.test/deepzoom/sample_files/9/1_1.jpg",

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -64,6 +64,29 @@ function fixtureFor(target, origin) {
     );
   }
 
+  if (href === "https://fixtures.test/zoomify-base-href/product.html") {
+    return html(`
+      <!doctype html>
+      <html>
+        <head>
+          <base href="https://fixtures.test/zoomify-base-href/assets/">
+        </head>
+        <body>
+          <script>
+            Z.showImage("viewer", "maps/sample");
+            Z.showImage("viewer", "maps/missing");
+          </script>
+        </body>
+      </html>
+    `);
+  }
+
+  if (href === "https://fixtures.test/zoomify-base-href/assets/maps/sample/ImageProperties.xml") {
+    return xml(
+      '<IMAGE_PROPERTIES WIDTH="512" HEIGHT="512" NUMTILES="5" VERSION="1.8" TILESIZE="256" />'
+    );
+  }
+
   if (href === "https://fixtures.test/deepzoom/sample.dzi") {
     return xml(
       '<Image TileSize="256" Overlap="0" Format="jpg" xmlns="http://schemas.microsoft.com/deepzoom/2008"><Size Width="512" Height="512" /></Image>'

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -62,6 +62,11 @@ const targets = [
     url: "https://www.neptunelabs.com/fsi-viewer/",
   },
   {
+    name: "Geographicus",
+    expectedDezoomer: "Zoomify",
+    url: "https://www.geographicus.com/P/AntiqueMap/nantucket-sheminroyster-1973",
+  },
+  {
     name: "OpenSeadragon Zoomify",
     expectedDezoomer: "Zoomify",
     url: "https://openseadragon.github.io/examples/tilesource-zoomify/",


### PR DESCRIPTION
Closes #861

This fixes Zoomify autodiscovery for geographicus.com pages whose Z.showImage paths are relative to the document <base href>. It adds deterministic fixture coverage and the Geographicus live compatibility target.

Tests:
- cd tests && env CI=1 npm test
- cd tests && env CI=1 ./node_modules/.bin/playwright test --config live-playwright.config.js --grep Geographicus