### PR TITLE
iiif: discover bare service roots in pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The most prominent supported websites with live compatibility tests include :
 - Arts & Culture (artsandculture.google.com)
 - Czech Digital Library (api.ceskadigitalniknihovna.cz)
 - Memoire des hommes (memoiredeshommes.defense.gouv.fr)
+- London Museum collections (londonmuseum.org.uk)
 - National Gallery (nationalgallery.org.uk)
 - National Gallery of Victoria (ngv.vic.gov.au)
 - CSNTM manuscripts (collections.csntm.org)

--- a/dezoomers/iiif.js
+++ b/dezoomers/iiif.js
@@ -15,9 +15,13 @@ var iiif = (function () {
   var relativeUrlReg = new RegExp(
     "((?:/|\\.\\.?/)[^\"'\\s<>]+)" + iiifPathRegExp
   );
+  var londonMuseumServiceRootReg =
+    /(https?:\/\/collections\.londonmuseum\.net\/iiif\/3\/[^"'\s<>]+?\.ptif)(?=["'\s<>])/;
   var gallicaReg = /https?:\/\/gallica\.bnf\.fr\/ark:\/(\w+\/\w+)(?:\/(f\w+))?/
   function extractUrl(text, baseUrl) {
-    var match = text.match(urlReg) || text.match(relativeUrlReg);
+    var match = text.match(urlReg) ||
+      text.match(relativeUrlReg) ||
+      text.match(londonMuseumServiceRootReg);
     if (!match) return null;
     var result = match[1] + "/info.json";
     if (baseUrl) result = ZoomManager.resolveRelative(result, baseUrl);
@@ -42,7 +46,7 @@ var iiif = (function () {
     "name": "IIIF",
     "description": "International Image Interoperability Framework",
     "urls": [urlReg, gallicaReg],
-    "contents": [urlReg, relativeUrlReg],
+    "contents": [urlReg, relativeUrlReg, londonMuseumServiceRootReg],
     "findFile": function getInfoFile(baseUrl, callback) {
 
       var gallicaMatch = baseUrl.match(gallicaReg);
@@ -124,8 +128,12 @@ var iiif = (function () {
           "height": parseInt(data.height),
           "tileSize": tiles.width,
           "maxZoomLevel": Math.min.apply(null, tiles.scaleFactors),
-          "quality": searchWithDefault(data.qualities || data.extraQualities, "native", "default"),
-          "format": searchWithDefault(data.formats || data.extraFormats, "png", "jpg")
+          "quality": data.qualities
+            ? searchWithDefault(data.qualities, "native", "default")
+            : "default",
+          "format": data.formats
+            ? searchWithDefault(data.formats, "png", "jpg")
+            : "jpg"
         };
         var img = new Image; // Load a tile to find out the real tile size
         img.src = getTileURL(0, 0, returned_data.maxZoomLevel, returned_data);

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -291,4 +291,14 @@ test.describe("dezoomer fixture coverage", () => {
     );
   });
 
+  test("extracts London Museum bare IIIF service roots from pages", async ({ page }) => {
+    const result = await runDezoomer(page, "Select automatically", "https://fixtures.test/londonmuseum-object");
+
+    expect(result.dezoomerName).toBe("IIIF");
+    expect(result.data.origin).toBe("http://127.0.0.1:9877/iiif/londonmuseum/object-95380.ptif");
+    expect(result.tiles.at(-1).url).toContain(
+      "/iiif/londonmuseum/object-95380.ptif/256,256,256,256/256,256/0/default.jpg"
+    );
+  });
+
 });

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -167,6 +167,26 @@ function fixtureFor(target, origin) {
     `);
   }
 
+  if (href === "https://fixtures.test/londonmuseum-object") {
+    return html(`
+      <img data-src="https://collections.londonmuseum.net/iiif/3/object-95380.ptif">
+    `);
+  }
+
+  if (href === "https://collections.londonmuseum.net/iiif/3/object-95380.ptif/info.json") {
+    return json({
+      "@context": "http://iiif.io/api/image/3/context.json",
+      id: `${origin}/iiif/londonmuseum/object-95380.ptif`,
+      type: "ImageService3",
+      width: 512,
+      height: 512,
+      tiles: [{ width: 256, height: 256, scaleFactors: [1, 2] }],
+      profile: "level2",
+      extraQualities: ["bitonal", "color", "gray"],
+      extraFormats: ["tif", "gif"],
+    });
+  }
+
   if (
     href ===
     "https://fixtures.test/server.iip?IIIF=/fronts/N-6660-00-000003-FS-PYR.tif/info.json"

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -17,6 +17,11 @@ const targets = [
     url: "https://www.memoiredeshommes.defense.gouv.fr/_recherche-images/show/112145/image/56545/0/info.json",
   },
   {
+    name: "London Museum collections",
+    expectedDezoomer: "IIIF",
+    url: "https://www.londonmuseum.org.uk/collections/v/object-95380/a-country-fair/",
+  },
+  {
     name: "National Gallery of Victoria",
     expectedDezoomer: "Zoomify",
     url: "https://www.ngv.vic.gov.au/explore/collection/work/3867/",


### PR DESCRIPTION
## Summary
- discover London Museum bare IIIF Image API service roots embedded in object page HTML
- use IIIF v3 default jpg tiles when only extra quality/format lists are present, matching collections.londonmuseum.net behavior
- add deterministic and live compatibility coverage plus README listing for London Museum collections

Closes #869

Validated against londonmuseum.org.uk object pages and collections.londonmuseum.net IIIF services.

## Tests
- npm test
- npx playwright test --config live-playwright.config.js -g "London Museum collections"