### PR TITLE
iiif: parse Mirador manifest URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The most prominent supported websites with live compatibility tests include :
 - Oklahoma State University Digital Collections (dc.library.okstate.edu)
 - OpenSeadragon Zoomify examples (openseadragon.github.io)
 - PNAV collection sites, including catalog.shm.ru, collection.pushkinmuseum.art, and collection.ethnomuseum.ru
+- University of Washington Digital Collections Mirador (digitalcollections.lib.washington.edu)
 
 
 Dezoomify also has a

--- a/dezoomers/iiif.js
+++ b/dezoomers/iiif.js
@@ -18,6 +18,7 @@ var iiif = (function () {
   var londonMuseumServiceRootReg =
     /(https?:\/\/collections\.londonmuseum\.net\/iiif\/3\/[^"'\s<>]+?\.ptif)(?=["'\s<>])/;
   var contentdmRecordReg = /^(https?:\/\/[^/]+)(\/digital)\/collection\/([^/?#]+)\/id\/(\d+)(?:[/?#]|$)/;
+  var manifestParamReg = /^https?:\/\/[^?#]+[?&][^#]*\bmanifest=/;
   var gallicaReg = /https?:\/\/gallica\.bnf\.fr\/ark:\/(\w+\/\w+)(?:\/(f\w+))?/
   function extractUrl(text, baseUrl) {
     var match = text.match(urlReg) ||
@@ -49,10 +50,47 @@ var iiif = (function () {
     if (info.iiifInfoUri.indexOf("/") === 0) return origin + appPath + info.iiifInfoUri;
     return origin + appPath + "/" + info.iiifInfoUri;
   }
+  function manifestParamUrl(baseUrl) {
+    try {
+      return new URL(baseUrl).searchParams.get("manifest");
+    } catch (e) {
+      var match = String(baseUrl).match(/[?&]manifest=([^&#]+)/);
+      return match && decodeURIComponent(match[1]);
+    }
+  }
+  function imageServiceInfoUrl(service) {
+    if (!service || typeof service !== "object") return null;
+    var url = service["@id"] || service.id;
+    if (!url) return null;
+    var isImageService =
+      String(service.profile || "").indexOf("iiif.io/api/image/") >= 0 ||
+      String(service["@context"] || "").indexOf("iiif.io/api/image/") >= 0;
+    if (!isImageService) return null;
+    if (/\/info\.json(?:[?#].*)?$/.test(url)) return url;
+    return url.replace(/\/?([?#].*)?$/, "/info.json$1");
+  }
+  function firstPresentationImageServiceInfoUrl(manifest) {
+    var sequences = manifest && manifest.sequences;
+    for (var i = 0; sequences && i < sequences.length; i++) {
+      var canvases = sequences[i].canvases;
+      for (var j = 0; canvases && j < canvases.length; j++) {
+        var images = canvases[j].images;
+        for (var k = 0; images && k < images.length; k++) {
+          var service = images[k].resource && images[k].resource.service;
+          var services = service && service.length ? service : [service];
+          for (var l = 0; l < services.length; l++) {
+            var infoUrl = imageServiceInfoUrl(services[l]);
+            if (infoUrl) return infoUrl;
+          }
+        }
+      }
+    }
+    return null;
+  }
   return {
     "name": "IIIF",
     "description": "International Image Interoperability Framework",
-    "urls": [urlReg, gallicaReg, contentdmRecordReg],
+    "urls": [urlReg, gallicaReg, contentdmRecordReg, manifestParamReg],
     "contents": [urlReg, relativeUrlReg, londonMuseumServiceRootReg],
     "findFile": function getInfoFile(baseUrl, callback) {
 
@@ -76,6 +114,15 @@ var iiif = (function () {
           var url = contentdmInfoUrl(info, contentdmMatch[1], contentdmMatch[2]);
           if (url) return callback(url);
           throw new Error("No CONTENTdm IIIF URL found.");
+        });
+      }
+
+      var manifestUrl = manifestParamUrl(baseUrl);
+      if (manifestUrl) {
+        return ZoomManager.getFile(manifestUrl, { type: "json" }, function (manifest) {
+          var infoUrl = firstPresentationImageServiceInfoUrl(manifest);
+          if (infoUrl) return callback(infoUrl);
+          throw new Error("No IIIF Image API service found in manifest.");
         });
       }
 

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -130,6 +130,11 @@ test.describe("dezoomer fixture coverage", () => {
         expectedTile: "/iiif/v2/256,256,256,256/256,256/0/native.png",
       },
       {
+        dezoomer: "IIIF",
+        url: "https://fixtures.test/mirador?manifest=https://fixtures.test/iiif-presentation/manifest.json",
+        expectedTile: "/iiif/mirador/256,256,256,256/256,256/0/native.jpg",
+      },
+      {
         dezoomer: "IIPImage",
         url: "https://fixtures.test/iip?FIF=/image.tif",
         expectedTile: "https://fixtures.test/iip?FIF=/image.tif&JTL=1,3",
@@ -291,6 +296,14 @@ test.describe("dezoomer fixture coverage", () => {
     expect(result.tiles.at(-1).url).toContain(
       "/digital/iiif/OKMaps/6483/256,256,256,256/256,256/0/native.jpg"
     );
+  });
+
+  test("rejects IIIF Presentation manifests with only plain images", async ({ page }) => {
+    await expect(runDezoomer(
+      page,
+      "Select automatically",
+      "https://fixtures.test/mirador?manifest=https://fixtures.test/iiif-presentation/plain-image-manifest.json"
+    )).rejects.toThrow("No IIIF Image API service found in manifest.");
   });
 
   test("extracts current National Gallery IIIF URLs from pages", async ({ page }) => {

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -134,6 +134,67 @@ function fixtureFor(target, origin) {
     });
   }
 
+  if (href === "https://fixtures.test/mirador?manifest=https://fixtures.test/iiif-presentation/manifest.json") {
+    return html("<title>Mirador fixture</title>");
+  }
+
+  if (href === "https://fixtures.test/iiif-presentation/manifest.json") {
+    return json({
+      "@context": "http://iiif.io/api/presentation/2/context.json",
+      "@id": "https://fixtures.test/iiif-presentation/manifest.json",
+      "@type": "sc:Manifest",
+      sequences: [{
+        canvases: [{
+          images: [{
+            resource: {
+              "@id": "https://fixtures.test/iiif-presentation/full.jpg",
+              service: [{
+                "@context": "http://iiif.io/api/image/2/context.json",
+                "@id": "https://fixtures.test/iiif-presentation/image",
+                profile: "http://iiif.io/api/image/2/level2.json",
+              }],
+            },
+          }],
+        }],
+      }],
+    });
+  }
+
+  if (href === "https://fixtures.test/iiif-presentation/image/info.json") {
+    return json({
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": `${origin}/iiif/mirador`,
+      width: 512,
+      height: 512,
+      tiles: [{ width: 256, height: 256, scaleFactors: [1, 2] }],
+      qualities: ["native"],
+      formats: ["jpg"],
+    });
+  }
+
+  if (href === "https://fixtures.test/mirador?manifest=https://fixtures.test/iiif-presentation/plain-image-manifest.json") {
+    return html("<title>Plain image Mirador fixture</title>");
+  }
+
+  if (href === "https://fixtures.test/iiif-presentation/plain-image-manifest.json") {
+    return json({
+      "@context": "http://iiif.io/api/presentation/2/context.json",
+      "@id": "https://fixtures.test/iiif-presentation/plain-image-manifest.json",
+      "@type": "sc:Manifest",
+      sequences: [{
+        canvases: [{
+          images: [{
+            resource: {
+              "@id": "https://fixtures.test/iiif-presentation/plain.jpg",
+              "@type": "dctypes:Image",
+              format: "image/jpeg",
+            },
+          }],
+        }],
+      }],
+    });
+  }
+
   if (
     href === "https://fixtures.test/iiif-private-id/info.json" ||
     href === `${origin}/fixtures/iiif-private-id/info.json`

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -47,6 +47,11 @@ const targets = [
     url: "https://dc.library.okstate.edu/digital/collection/OKMaps/id/6483/rec/6",
   },
   {
+    name: "University of Washington Mirador",
+    expectedDezoomer: "IIIF",
+    url: "https://digitalcollections.lib.washington.edu/digital/custom/mirador3?manifest=https://digitalcollections.lib.washington.edu//iiif/info/social/1303/manifest.json",
+  },
+  {
     name: "krpano",
     expectedDezoomer: "krpano",
     url: "https://krpano.com/panos/andreabiffi/galleria_04.xml",


### PR DESCRIPTION
## Summary
- detect viewer URLs with a manifest= query parameter in the IIIF dezoomer
- fetch IIIF Presentation v2 manifests and use the first Image API service from sequences/canvases/images/resource.service
- add deterministic Mirador manifest fixtures, a plain-JPEG negative fixture, and a live University of Washington compatibility target

## Verification
- cd tests && npm test
- cd tests && npm run test:live -- --grep "University of Washington Mirador"

Closes #801.
Refs #935.