### PR TITLE
iiif: discover Micrio custom elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The most prominent supported websites with live compatibility tests include :
 - Czech Digital Library (api.ceskadigitalniknihovna.cz)
 - Memoire des hommes (memoiredeshommes.defense.gouv.fr)
 - London Museum collections (londonmuseum.org.uk)
+- Liechtenstein Collections (liechtensteincollections.at)
 - National Gallery (nationalgallery.org.uk)
 - National Gallery of Victoria (ngv.vic.gov.au)
 - Philadelphia Museum of Art (philamuseum.org)

--- a/dezoomers/iiif.js
+++ b/dezoomers/iiif.js
@@ -22,12 +22,19 @@ var iiif = (function () {
   var contentdmRecordReg = /^(https?:\/\/[^/]+)(\/digital)\/collection\/([^/?#]+)\/id\/(\d+)(?:[/?#]|$)/;
   var manifestParamReg = /^https?:\/\/[^?#]+[?&][^#]*\bmanifest=/;
   var gallicaReg = /https?:\/\/gallica\.bnf\.fr\/ark:\/(\w+\/\w+)(?:\/(f\w+))?/
+  var micrioCustomElementReg = /<micr-io\b[^>]*\bid=["']([A-Za-z0-9]{5})["'][^>]*>/i;
   function extractUrl(text, baseUrl) {
     var match = text.match(urlReg) ||
       text.match(relativeUrlReg) ||
       text.match(londonMuseumServiceRootReg);
-    if (!match) return null;
-    var result = match[1] + "/info.json";
+    var result;
+    if (match) {
+      result = match[1] + "/info.json";
+    } else {
+      match = text.match(micrioCustomElementReg);
+      if (!match) return null;
+      result = "https://i.micr.io/" + match[1] + "/info.json";
+    }
     if (baseUrl) result = ZoomManager.resolveRelative(result, baseUrl);
     // Van Gogh Museum has hash-protected URLs on micrio.* but not micrio-cdn.* 
     result = result.replace('micrio.vangoghmuseum.nl/iiif', 'micrio-cdn.vangoghmuseum.nl');
@@ -98,7 +105,13 @@ var iiif = (function () {
     "name": "IIIF",
     "description": "International Image Interoperability Framework",
     "urls": [urlReg, gallicaReg, contentdmRecordReg, manifestParamReg],
-    "contents": [urlReg, relativeUrlReg, londonMuseumServiceRootReg, philadelphiaMuseumMicrioShortIdReg],
+    "contents": [
+      urlReg,
+      relativeUrlReg,
+      londonMuseumServiceRootReg,
+      philadelphiaMuseumMicrioShortIdReg,
+      micrioCustomElementReg,
+    ],
     "findFile": function getInfoFile(baseUrl, callback) {
 
       var gallicaMatch = baseUrl.match(gallicaReg);

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -135,6 +135,11 @@ test.describe("dezoomer fixture coverage", () => {
         expectedTile: "/iiif/mirador/256,256,256,256/256,256/0/native.jpg",
       },
       {
+        dezoomer: "IIIF",
+        url: "https://fixtures.test/micrio-custom-element",
+        expectedTile: "https://iiif.micr.io/KEimL/256,256,256,256/256,256/0/default.jpg",
+      },
+      {
         dezoomer: "IIPImage",
         url: "https://fixtures.test/iip?FIF=/image.tif",
         expectedTile: "https://fixtures.test/iip?FIF=/image.tif&JTL=1,3",

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -295,6 +295,29 @@ function fixtureFor(target, origin) {
     });
   }
 
+  if (href === "https://fixtures.test/micrio-custom-element") {
+    return html(`
+      <!doctype html>
+      <html>
+        <body>
+          <micr-io data-view="default" id="KEimL"></micr-io>
+        </body>
+      </html>
+    `);
+  }
+
+  if (href === "https://i.micr.io/KEimL/info.json") {
+    return json({
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": "https://iiif.micr.io/KEimL",
+      width: 512,
+      height: 512,
+      tiles: [{ width: 256, height: 256, scaleFactors: [1, 2] }],
+      qualities: ["default"],
+      formats: ["jpg"],
+    });
+  }
+
   if (href === "https://collections.londonmuseum.net/iiif/3/object-95380.ptif/info.json") {
     return json({
       "@context": "http://iiif.io/api/image/3/context.json",

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -27,6 +27,11 @@ const targets = [
     url: "https://philamuseum.org/collection/object/101731",
   },
   {
+    name: "Liechtenstein Collections",
+    expectedDezoomer: "IIIF",
+    url: "https://www.liechtensteincollections.at/en/collections-online/forest-landscape",
+  },
+  {
     name: "National Gallery of Victoria",
     expectedDezoomer: "Zoomify",
     url: "https://www.ngv.vic.gov.au/explore/collection/work/3867/",


### PR DESCRIPTION
## Summary
- discover Micrio custom-element ids in IIIF HTML autodiscovery
- resolve `<micr-io id=...>` to `https://i.micr.io/{id}/info.json`
- add deterministic fixture coverage and a Liechtenstein live compatibility target

## Verification
- `cd tests && npm test`
- `cd tests && npm run test:live -- --grep "Liechtenstein Collections"`

Closes #645
Refs #471
Refs #935