### PR TITLE
lizardtech: support direct calcrgn URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following formats are supported by dezoomify:
 * **TopViewer**, also named **Memorix Maior picture viewer**, used by Picturae Memorix sites.
 * [krpano Panorama Viewer](http://krpano.com), mainly used in panoramic images and interactive virtual tours.
 * [FSI Viewer](https://www.neptunelabs.com/products/fsi-viewer/), zoomable image server by NeptuneLabs GmbH.
+* [LizardTech ImageServer](https://www.extensis.com/support/geospatial), for direct ImageServer `calcrgn` URLs.
 * [Visual Library Server](https://www.semantics.de/visual_library/), by semantics
 * [Micr.io](https://micr.io/)'s non-IIIF format.
 * [Hungaricana](https://hungaricana.hu/en/) a format found only on the **Hungarian Cultural Heritage Portal**, that hosts half a million images.
@@ -57,6 +58,7 @@ The most prominent supported websites with live compatibility tests include :
 - Westchester County Archives (collections.westchestergov.com)
 - Bibliotheques specialisees de Paris (bibliotheques-specialisees.paris.fr)
 - FSI Viewer examples (neptunelabs.com)
+- LizardTech ImageServer on Alabama Maps (cartweb.geography.ua.edu)
 - Geographicus (geographicus.com)
 - krpano examples (krpano.com)
 - Memorix TopViewer sites (images.memorix.nl)

--- a/dezoomers/lizardtech.js
+++ b/dezoomers/lizardtech.js
@@ -1,0 +1,103 @@
+var lizardtech = (function () {
+	function textContent(node) {
+		return node && (node.textContent || node.innerText || "");
+	}
+
+	function requestParameter(doc, name) {
+		var params = doc.getElementsByTagName("Parameter");
+		for (var i = 0; i < params.length; i++) {
+			if (params[i].getAttribute("name") === name) {
+				return textContent(params[i]);
+			}
+		}
+		return "";
+	}
+
+	function buildLevels(width, height) {
+		var tileSize = 512;
+		var levels = [];
+		var level = 0;
+
+		do {
+			levels.push({ width: width, height: height, level: level, dx: 0, dy: 0 });
+			width = Math.ceil(width / 2);
+			height = Math.ceil(height / 2);
+			level++;
+		} while (2 * Math.max(width, height) > tileSize);
+
+		levels.reverse();
+
+		var size = tileSize;
+		for (var i = 0; i < levels.length; i++, size *= 2) {
+			levels[i].dx = (size - levels[i].width) / (2 * levels[i].width);
+			levels[i].dy = (size - levels[i].height) / (2 * levels[i].height);
+		}
+
+		return levels;
+	}
+
+	return {
+		name: "LizardTech ImageServer",
+		description: "LizardTech ImageServer direct calcrgn URLs",
+		urls: [
+			/\/lizardtech\/iserv\/calcrgn\?/i
+		],
+		open: function (url) {
+			ZoomManager.getFile(url, { type: "xml" }, function (doc) {
+				var server = doc.getElementsByTagName("ImageServer")[0];
+				var catalog = doc.getElementsByTagName("Catalog")[0];
+				var image = doc.getElementsByTagName("Image")[0];
+				if (!server || !catalog || !image) {
+					return ZoomManager.error("Invalid LizardTech ImageServer XML: " + url);
+				}
+
+				var width = parseInt(image.getAttribute("width"));
+				var height = parseInt(image.getAttribute("height"));
+				if (!width || !height) {
+					return ZoomManager.error("Missing LizardTech image dimensions: " + url);
+				}
+
+				var source = new URL(url);
+				var host = server.getAttribute("host") || source.host;
+				var path = (server.getAttribute("path") || "lizardtech/iserv").replace(/^\/|\/$/g, "");
+				var item = requestParameter(doc, "item");
+				if (!item) {
+					var parent = image.getAttribute("parent");
+					var name = image.getAttribute("name");
+					item = parent ? parent + "/" + name : name;
+				}
+
+				var data = {
+					origin: source.protocol + "//" + host + "/" + path + "/calcrgn",
+					host: host,
+					path: path,
+					catalog: catalog.getAttribute("name") || requestParameter(doc, "cat"),
+					item: item,
+					width: width,
+					height: height,
+					numlevels: parseInt(image.getAttribute("numlevels")),
+					tileSize: 512,
+					maxZoomLevel: 0,
+					levels: buildLevels(width, height),
+				};
+				data.maxZoomLevel = data.levels.length - 1;
+
+				ZoomManager.readyToRender(data);
+			});
+		},
+		getTileURL: function (x, y, zoom, data) {
+			var level = data.levels[zoom];
+			var centerX = ((x + 0.5) * data.tileSize) / level.width - level.dx;
+			var centerY = ((y + 0.5) * data.tileSize) / level.height - level.dy;
+			return (
+				data.origin.replace(/\/calcrgn$/, "/getimage") +
+				"?cat=" + encodeURIComponent(data.catalog) +
+				"&item=" + encodeURIComponent(data.item) +
+				"&wid=512&hei=512&oif=jpeg" +
+				"&lev=" + level.level +
+				"&cp=" + centerX + "," + centerY
+			);
+		}
+	};
+})();
+ZoomManager.addDezoomer(lizardtech);

--- a/index.html
+++ b/index.html
@@ -191,6 +191,7 @@
   <script type="text/javascript" src="dezoomers/krpano.js"></script>
   <script type="text/javascript" src="dezoomers/iiif.js"></script>
   <script type="text/javascript" src="dezoomers/fsi.js"></script>
+  <script type="text/javascript" src="dezoomers/lizardtech.js"></script>
   <script type="text/javascript" src="dezoomers/vls.js"></script>
   <script type="text/javascript" src="dezoomers/micrio.js"></script>
   <script type="module" src="dezoomers/arts-culture.js"></script>

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -170,6 +170,11 @@ test.describe("dezoomer fixture coverage", () => {
         expectedTile: "https://fixtures.test/fsi/server?type=image&source=image",
       },
       {
+        dezoomer: "LizardTech ImageServer",
+        url: "https://fixtures.test/lizardtech/iserv/calcrgn?cat=North%20America%20and%20United%20States&item=NorthAmerica/US1566a.sid&wid=500&hei=400&props=item(Name,Description),cat(Name,Description)&style=default/view.xsl&plugin=true",
+        expectedTile: "https://fixtures.test/lizardtech/iserv/getimage?cat=North%20America%20and%20United%20States&item=NorthAmerica%2FUS1566a.sid&wid=512&hei=512&oif=jpeg&lev=0&cp=0.75,0.75",
+      },
+      {
         dezoomer: "VLS",
         url: "https://fixtures.test/vls/zoom/1",
         expectedTile: "https://fixtures.test/image/tiler/square/fixture/0/0/0",

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -356,6 +356,25 @@ function fixtureFor(target, origin) {
     return text('<property width value="512" /><property height value="512" />');
   }
 
+  if (
+    href ===
+    "https://fixtures.test/lizardtech/iserv/calcrgn?cat=North%20America%20and%20United%20States&item=NorthAmerica/US1566a.sid&wid=500&hei=400&props=item(Name,Description),cat(Name,Description)&style=default/view.xsl&plugin=true"
+  ) {
+    return xml(`
+      <ImageServer host="fixtures.test" path="lizardtech/iserv" version="9.5.0.4547">
+        <Request command="calcrgn">
+          <Parameter name="cat">North America and United States</Parameter>
+          <Parameter name="item">NorthAmerica/US1566a.sid</Parameter>
+        </Request>
+        <Response>
+          <Catalog name="North America and United States">
+            <Image width="1024" height="1024" name="US1566a.sid" parent="NorthAmerica" numlevels="10" />
+          </Catalog>
+        </Response>
+      </ImageServer>
+    `);
+  }
+
   if (href === "https://fixtures.test/vls/zoom/1") {
     return xml(`
       <root>

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -77,6 +77,11 @@ const targets = [
     url: "https://www.neptunelabs.com/fsi-viewer/",
   },
   {
+    name: "Alabama Maps LizardTech",
+    expectedDezoomer: "LizardTech ImageServer",
+    url: "http://cartweb.geography.ua.edu/lizardtech/iserv/calcrgn?cat=North%20America%20and%20United%20States&item=NorthAmerica/US1566a.sid&wid=500&hei=400&props=item(Name,Description),cat(Name,Description)&style=default/view.xsl&plugin=true",
+  },
+  {
     name: "Geographicus",
     expectedDezoomer: "Zoomify",
     url: "https://www.geographicus.com/P/AntiqueMap/nantucket-sheminroyster-1973",


### PR DESCRIPTION
Closes #905

## Summary
- add a narrow LizardTech ImageServer dezoomer for direct calcrgn URLs
- parse ImageServer XML metadata and generate 512px getimage tile URLs
- add deterministic fixture coverage and a focused Alabama Maps live compatibility target

## Verification
- cd tests && npm test
- cd tests && npm run test:live -- --grep "Alabama Maps LizardTech"