### PR TITLE
docs: update LizardTech protocol link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following formats are supported by dezoomify:
 * **TopViewer**, also named **Memorix Maior picture viewer**, used by Picturae Memorix sites.
 * [krpano Panorama Viewer](http://krpano.com), mainly used in panoramic images and interactive virtual tours.
 * [FSI Viewer](https://www.neptunelabs.com/products/fsi-viewer/), zoomable image server by NeptuneLabs GmbH.
-* [LizardTech ImageServer](https://www.extensis.com/support/geospatial), for direct ImageServer `calcrgn` URLs.
+* [LizardTech ImageServer](https://www.lizardtech.com/_files/ugd/04ad27_586a81cf99d349df926fba35b0f55b3d.pdf), for direct ImageServer `calcrgn` URLs.
 * [Visual Library Server](https://www.semantics.de/visual_library/), by semantics
 * [Micr.io](https://micr.io/)'s non-IIIF format.
 * [Hungaricana](https://hungaricana.hu/en/) a format found only on the **Hungarian Cultural Heritage Portal**, that hosts half a million images.


### PR DESCRIPTION
Replaces the dead Extensis geospatial URL with a reachable LizardTech Express Server user manual link for the ImageServer protocol documented by the new dezoomer.

Follow-up to #948.
