### PR TITLE
Add Prado artwork page support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following formats are supported by dezoomify:
 * [Deep Zoom](http://en.wikipedia.org/wiki/Deep_Zoom) : Zoomable image format created by Microsoft.
 * [Arts & Culture](https://artsandculture.google.com/) (formerly Google Art Project): a cooperation between google and several international museums. [More info about the controversy around this dezoomer.](https://github.com/lovasoa/dezoomify/issues/435).
 * [IIIF](https://iiif.io): The International Image Interoperability Framework, used on many websites, including [National Gallery](https://www.nationalgallery.org.uk/), [National Library of Israel](https://www.nli.org.il/), and [National Library of Scotland](https://www.nls.uk/).
+* [Museo Nacional del Prado](https://www.museodelprado.es/): artwork pages using Prado's OpenSeadragon image viewer.
 * [Zoomify single-file format](https://github.com/lovasoa/pff-extract/wiki/Zoomify-PFF-file-format-documentation) : Less common format used by zoomify, where all tiles are in a single *.pff* file, and are queried through a java servlet.
 * [XLimage](http://www.centrica.it/products/xlimage-2/), a zoomable image format developed by an Italian company.
 * **TopViewer**, also named **Memorix Maior picture viewer**, used by Picturae Memorix sites.

--- a/dezoomers/seadragon.js
+++ b/dezoomers/seadragon.js
@@ -1,9 +1,34 @@
 var seadragon = (function () { //Code isolation
+	function pradoDeepZoomDataFromPage(text, baseUrl) {
+		var doc = new DOMParser().parseFromString(text, "text/html");
+		var image = doc.querySelector("img.img_cache[data-pyr][data-width][data-height]");
+		if (!image) return null;
+
+		var origin = image.getAttribute("data-pyr");
+		var width = parseInt(image.getAttribute("data-width"), 10);
+		var height = parseInt(image.getAttribute("data-height"), 10);
+		if (!origin || !width || !height) return null;
+
+		origin = ZoomManager.resolveRelative(origin, baseUrl);
+		if (origin.slice(-1) !== "/") origin += "/";
+
+		return {
+			origin: origin,
+			tileSize: 256,
+			overlap: 1,
+			format: "jpg",
+			width: width,
+			height: height,
+			zoomFactor: 2,
+			maxZoomLevel: Math.ceil(Math.log2(Math.max(width, height)))
+		};
+	}
 
 	return {
 		"name": "Seadragon (Deep Zoom Image)",
 		"description": "Microsoft zoomable image format, sometimes called DZI, seadragon, or deep zoom",
 		"urls": [
+			/museodelprado\.es\/(?:en\/the-collection|coleccion)\/(?:art-work|obra-de-arte)\//,
 			/bl\.uk\/manuscripts\/Viewer\.aspx/,
 			/polona\.pl\/item\//,
 			/bibliotheques-specialisees\.paris\.fr\/ark/,
@@ -12,6 +37,7 @@ var seadragon = (function () { //Code isolation
 			/dzi$/
 		],
 		"contents": [
+			/data-pyr=["'][^"']+["'][^>]*\bimg_cache\b|\bimg_cache\b[^>]*data-pyr=/i,
 			/dziUrlTemplate/,
 			/Seadragon\.embed\([^)]*["'][^"']+\.(?:xml|dzi)(?:\?[^"']*)?["']/i,
 			/[^"'()<>]+\.(?:dzi)/i,
@@ -92,6 +118,9 @@ var seadragon = (function () { //Code isolation
 					return callback(url);
 				}
 
+				var pradoData = pradoDeepZoomDataFromPage(text, baseUrl);
+				if (pradoData) return callback(baseUrl, { deepZoomData: pradoData });
+
 				var seadragonEmbedMatch = text.match(/Seadragon\.embed\([^)]*["']([^"']+\.(?:xml|dzi)(?:\?[^"']*)?)["'][^)]*\)/i);
 				if (seadragonEmbedMatch) return callback(seadragonEmbedMatch[1]);
 
@@ -106,7 +135,9 @@ var seadragon = (function () { //Code isolation
 				return callback(baseUrl);
 			});
 		},
-		"open": function (url) {
+		"open": function (url, infos) {
+			if (infos && infos.deepZoomData) return ZoomManager.readyToRender(infos.deepZoomData);
+
 			ZoomManager.getFile(url, { type: "xml" }, function (xml, xhr) {
 				var infos = xml.getElementsByTagName("Image")[0];
 				var size = xml.getElementsByTagName("Size")[0];

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -338,6 +338,27 @@ test.describe("dezoomer fixture coverage", () => {
     );
   });
 
+  test("extracts Prado OpenSeadragon metadata from artwork pages", async ({ page }) => {
+    const result = await runDezoomer(
+      page,
+      "Select automatically",
+      "https://www.museodelprado.es/en/the-collection/art-work/las-meninas/9fdc7800-9ade-48b0-ab8b-edee94ea877f?searchid=0a27f161-5629-8f4a-2756-ff085078076e"
+    );
+
+    expect(result.dezoomerName).toBe("Seadragon (Deep Zoom Image)");
+    expect(result.data.origin).toBe(
+      "https://content3.cdnprado.net/imagenes/Documentos/imgsem/9f/9fdc/9fdc7800-9ade-48b0-ab8b-edee94ea877f/41866afd-6396-45e7-bd26-944263cf92f7/"
+    );
+    expect(result.data.width).toBe(2362);
+    expect(result.data.height).toBe(2697);
+    expect(result.data.tileSize).toBe(256);
+    expect(result.data.overlap).toBe(1);
+    expect(result.data.maxZoomLevel).toBe(12);
+    expect(result.tiles[0].url).toBe(
+      "https://content3.cdnprado.net/imagenes/Documentos/imgsem/9f/9fdc/9fdc7800-9ade-48b0-ab8b-edee94ea877f/41866afd-6396-45e7-bd26-944263cf92f7/12/0_0.jpg"
+    );
+  });
+
   test("extracts Philadelphia Museum Micrio short IDs as IIIF info URLs", async ({ page }) => {
     const cases = [
       { url: "https://fixtures.test/philamuseum-escaped-shortid", shortId: "QYRjM" },

--- a/tests/fixtures/remote/www.museodelprado.es/en/the-collection/art-work/las-meninas/9fdc7800-9ade-48b0-ab8b-edee94ea877f.html
+++ b/tests/fixtures/remote/www.museodelprado.es/en/the-collection/art-work/las-meninas/9fdc7800-9ade-48b0-ab8b-edee94ea877f.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Las Meninas - The Collection - Museo Nacional del Prado</title>
+  <script src="https://content3.cdnprado.net/ElPrado/js/templates/visor_openseadragon.js"></script>
+</head>
+<body>
+  <img
+    alt="Las Meninas"
+    data-lazy="https://content3.cdnprado.net/imagenes/Documentos/imgsem/9f/9fdc/9fdc7800-9ade-48b0-ab8b-edee94ea877f/41866afd-6396-45e7-bd26-944263cf92f7_832.jpg"
+    data-pyr="https://content3.cdnprado.net/imagenes/Documentos/imgsem/9f/9fdc/9fdc7800-9ade-48b0-ab8b-edee94ea877f/41866afd-6396-45e7-bd26-944263cf92f7/"
+    class="img_cache"
+    data-width="2362"
+    data-height="2697">
+  <img
+    alt="Las Meninas detail"
+    data-lazy="https://content3.cdnprado.net/imagenes/Documentos/imgsem/example/second_832.jpg"
+    data-pyr="https://content3.cdnprado.net/imagenes/Documentos/imgsem/example/second/"
+    class="img_cache"
+    data-width="1000"
+    data-height="1000">
+</body>
+</html>


### PR DESCRIPTION
## Summary
- detect Prado artwork pages that expose OpenSeadragon metadata in .img_cache elements
- reuse the Deep Zoom renderer with Prado's tile size, overlap, dimensions, and pyramid URL
- add deterministic Prado fixture coverage and README support entry

Fixes #206.

## Tests
- npm test