### PR TITLE
Add ONB IIIF Presentation v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following formats are supported by dezoomify:
 * [Zoomify](http://www.zoomify.com/) : Most common zoomable image format. *dezoomify* used to support only this, hence the name.
 * [Deep Zoom](http://en.wikipedia.org/wiki/Deep_Zoom) : Zoomable image format created by Microsoft.
 * [Arts & Culture](https://artsandculture.google.com/) (formerly Google Art Project): a cooperation between google and several international museums. [More info about the controversy around this dezoomer.](https://github.com/lovasoa/dezoomify/issues/435).
-* [IIIF](https://iiif.io): The International Image Interoperability Framework, used on many websites, including [National Gallery](https://www.nationalgallery.org.uk/), [National Library of Israel](https://www.nli.org.il/), and [National Library of Scotland](https://www.nls.uk/).
+* [IIIF](https://iiif.io): The International Image Interoperability Framework, used on many websites, including [Austrian National Library](https://www.onb.ac.at/), [National Gallery](https://www.nationalgallery.org.uk/), [National Library of Israel](https://www.nli.org.il/), and [National Library of Scotland](https://www.nls.uk/).
 * [Museo Nacional del Prado](https://www.museodelprado.es/): artwork pages using Prado's OpenSeadragon image viewer.
 * [Zoomify single-file format](https://github.com/lovasoa/pff-extract/wiki/Zoomify-PFF-file-format-documentation) : Less common format used by zoomify, where all tiles are in a single *.pff* file, and are queried through a java servlet.
 * [XLimage](http://www.centrica.it/products/xlimage-2/), a zoomable image format developed by an Italian company.
@@ -52,6 +52,7 @@ The most prominent supported websites with live compatibility tests include :
 - Liechtenstein Collections (liechtensteincollections.at)
 - National Gallery (nationalgallery.org.uk)
 - National Gallery of Victoria (ngv.vic.gov.au)
+- Austrian National Library (onb.ac.at)
 - Philadelphia Museum of Art (philamuseum.org)
 - CSNTM manuscripts (collections.csntm.org)
 - National Library of Australia (nla.gov.au)

--- a/dezoomers/iiif.js
+++ b/dezoomers/iiif.js
@@ -21,6 +21,9 @@ var iiif = (function () {
     /(?:philamuseum|Philadelphia Museum)[\s\S]*\\?"shortId\\?"\s*:\s*\\?"([A-Za-z0-9_-]{3,32})\\?"|\\?"shortId\\?"\s*:\s*\\?"([A-Za-z0-9_-]{3,32})\\?"[\s\S]*(?:philamuseum|Philadelphia Museum)/;
   var contentdmRecordReg = /^(https?:\/\/[^/]+)(\/digital)\/collection\/([^/?#]+)\/id\/(\d+)(?:[/?#]|$)/;
   var manifestParamReg = /^https?:\/\/[^?#]+[?&][^#]*\bmanifest=/;
+  var onbPresentationManifestReg = /^https?:\/\/api\.onb\.ac\.at\/iiif\/presentation\/v3\/manifest\/[^?#]+(?:[?#].*)?$/;
+  var onbViewerReg = /^https?:\/\/viewer\.onb\.ac\.at\/[^?#]+(?:[?#].*)?$/;
+  var onbRepViewerReg = /^https?:\/\/digital\.onb\.ac\.at\/RepViewer\/viewer\.faces\?(?=[^#]*\bdoc=)/;
   var gallicaReg = /https?:\/\/gallica\.bnf\.fr\/ark:\/(\w+\/\w+)(?:\/(f\w+))?/
   var micrioCustomElementReg = /<micr-io\b[^>]*\bid=["']([A-Za-z0-9]{5})["'][^>]*>/i;
   function extractUrl(text, baseUrl) {
@@ -72,16 +75,54 @@ var iiif = (function () {
       return match && decodeURIComponent(match[1]);
     }
   }
+  function onbManifestUrl(baseUrl) {
+    try {
+      var url = new URL(baseUrl);
+      var manifestPrefix = "/iiif/presentation/v3/manifest/";
+      if (url.hostname === "api.onb.ac.at" && url.pathname.indexOf(manifestPrefix) === 0) {
+        return url.href;
+      }
+      if (url.hostname === "viewer.onb.ac.at") {
+        var viewerId = url.pathname.replace(/^\/+|\/+$/g, "").split("/")[0];
+        if (viewerId) return "https://api.onb.ac.at/iiif/presentation/v3/manifest/" + viewerId;
+      }
+      if (url.hostname === "digital.onb.ac.at" && url.pathname === "/RepViewer/viewer.faces") {
+        var doc = url.searchParams.get("doc");
+        if (doc) return "https://api.onb.ac.at/iiif/presentation/v3/manifest/" + encodeURIComponent(doc);
+      }
+    } catch (e) {
+      return null;
+    }
+    return null;
+  }
   function imageServiceInfoUrl(service) {
     if (!service || typeof service !== "object") return null;
     var url = service["@id"] || service.id;
     if (!url) return null;
+    var serviceType = String(service.type || service["@type"] || "");
     var isImageService =
+      /^ImageService[0-9]?$/.test(serviceType) ||
       String(service.profile || "").indexOf("iiif.io/api/image/") >= 0 ||
       String(service["@context"] || "").indexOf("iiif.io/api/image/") >= 0;
     if (!isImageService) return null;
     if (/\/info\.json(?:[?#].*)?$/.test(url)) return url;
     return url.replace(/\/?([?#].*)?$/, "/info.json$1");
+  }
+  function firstServiceInfoUrl(service) {
+    var services = service && service.length ? service : [service];
+    for (var i = 0; i < services.length; i++) {
+      var infoUrl = imageServiceInfoUrl(services[i]);
+      if (infoUrl) return infoUrl;
+    }
+    return null;
+  }
+  function firstBodyImageServiceInfoUrl(body) {
+    var bodies = body && body.length ? body : [body];
+    for (var i = 0; i < bodies.length; i++) {
+      var infoUrl = bodies[i] && firstServiceInfoUrl(bodies[i].service);
+      if (infoUrl) return infoUrl;
+    }
+    return null;
   }
   function firstPresentationImageServiceInfoUrl(manifest) {
     var sequences = manifest && manifest.sequences;
@@ -91,11 +132,20 @@ var iiif = (function () {
         var images = canvases[j].images;
         for (var k = 0; images && k < images.length; k++) {
           var service = images[k].resource && images[k].resource.service;
-          var services = service && service.length ? service : [service];
-          for (var l = 0; l < services.length; l++) {
-            var infoUrl = imageServiceInfoUrl(services[l]);
-            if (infoUrl) return infoUrl;
-          }
+          var infoUrl = firstServiceInfoUrl(service);
+          if (infoUrl) return infoUrl;
+        }
+      }
+    }
+
+    var items = manifest && manifest.items;
+    for (var m = 0; items && m < items.length; m++) {
+      var annotationPages = items[m].items;
+      for (var n = 0; annotationPages && n < annotationPages.length; n++) {
+        var annotations = annotationPages[n].items;
+        for (var o = 0; annotations && o < annotations.length; o++) {
+          var bodyInfoUrl = firstBodyImageServiceInfoUrl(annotations[o].body);
+          if (bodyInfoUrl) return bodyInfoUrl;
         }
       }
     }
@@ -104,7 +154,7 @@ var iiif = (function () {
   return {
     "name": "IIIF",
     "description": "International Image Interoperability Framework",
-    "urls": [urlReg, gallicaReg, contentdmRecordReg, manifestParamReg],
+    "urls": [urlReg, gallicaReg, contentdmRecordReg, manifestParamReg, onbPresentationManifestReg, onbViewerReg, onbRepViewerReg],
     "contents": [
       urlReg,
       relativeUrlReg,
@@ -137,7 +187,7 @@ var iiif = (function () {
         });
       }
 
-      var manifestUrl = manifestParamUrl(baseUrl);
+      var manifestUrl = onbManifestUrl(baseUrl) || manifestParamUrl(baseUrl);
       if (manifestUrl) {
         return ZoomManager.getFile(manifestUrl, { type: "json" }, function (manifest) {
           var infoUrl = firstPresentationImageServiceInfoUrl(manifest);

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -231,6 +231,25 @@ test.describe("dezoomer fixture coverage", () => {
     expect(result.tiles.at(-1).url).toContain("/iiif/v3/256,256,256,256/256,256/0/default.jpg");
   });
 
+  test("discovers ONB IIIF Presentation 3 manifests", async ({ page }) => {
+    const cases = [
+      "https://viewer.onb.ac.at/10048A37/",
+      "https://viewer.onb.ac.at/10048A37/137",
+      "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37",
+      "https://digital.onb.ac.at/RepViewer/viewer.faces?doc=DTL_7039594&order=1&view=SINGLE",
+    ];
+
+    for (const url of cases) {
+      const result = await runDezoomer(page, "Select automatically", url);
+
+      expect(result.dezoomerName, url).toBe("IIIF");
+      expect(result.data.origin, url).toBe("http://127.0.0.1:9877/iiif/onb/10048A37/uk4nGb4kQHe3msbC");
+      expect(result.tiles.at(-1).url, url).toContain(
+        "/iiif/onb/10048A37/uk4nGb4kQHe3msbC/256,256,256,256/256,256/0/default.jpg"
+      );
+    }
+  });
+
   test("generates IIIF tile URLs with explicit returned dimensions", async ({ page }) => {
     const urls = await page.evaluate(() => {
       const iiif = window.ZoomManager.dezoomersList.IIIF;

--- a/tests/fixtures/remote/api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC/info.json
+++ b/tests/fixtures/remote/api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC/info.json
@@ -1,0 +1,9 @@
+{
+  "@context": "http://iiif.io/api/image/3/context.json",
+  "id": "{{origin}}/iiif/onb/10048A37/uk4nGb4kQHe3msbC",
+  "type": "ImageService3",
+  "width": 512,
+  "height": 512,
+  "tiles": [{ "width": 256, "height": 256, "scaleFactors": [1, 2] }],
+  "profile": "level2"
+}

--- a/tests/fixtures/remote/api.onb.ac.at/iiif/presentation/v3/manifest/10048A37.json
+++ b/tests/fixtures/remote/api.onb.ac.at/iiif/presentation/v3/manifest/10048A37.json
@@ -1,0 +1,32 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37",
+  "type": "Manifest",
+  "items": [{
+    "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/canvas/1",
+    "type": "Canvas",
+    "items": [{
+      "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/page/1",
+      "type": "AnnotationPage",
+      "items": [{
+        "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/annotation/1",
+        "type": "Annotation",
+        "motivation": "painting",
+        "body": {
+          "id": "https://api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC/full/300,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [{
+            "id": "https://api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC",
+            "type": "ImageService3",
+            "profile": "level2"
+          }, {
+            "id": "https://api.onb.ac.at/iiif/image/v3/10048A37/ignoredSecondService",
+            "type": "ImageService3",
+            "profile": "level2"
+          }]
+        }
+      }]
+    }]
+  }]
+}

--- a/tests/fixtures/remote/api.onb.ac.at/iiif/presentation/v3/manifest/DTL_7039594.json
+++ b/tests/fixtures/remote/api.onb.ac.at/iiif/presentation/v3/manifest/DTL_7039594.json
@@ -1,0 +1,32 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37",
+  "type": "Manifest",
+  "items": [{
+    "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/canvas/1",
+    "type": "Canvas",
+    "items": [{
+      "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/page/1",
+      "type": "AnnotationPage",
+      "items": [{
+        "id": "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37/annotation/1",
+        "type": "Annotation",
+        "motivation": "painting",
+        "body": {
+          "id": "https://api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC/full/300,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [{
+            "id": "https://api.onb.ac.at/iiif/image/v3/10048A37/uk4nGb4kQHe3msbC",
+            "type": "ImageService3",
+            "profile": "level2"
+          }, {
+            "id": "https://api.onb.ac.at/iiif/image/v3/10048A37/ignoredSecondService",
+            "type": "ImageService3",
+            "profile": "level2"
+          }]
+        }
+      }]
+    }]
+  }]
+}

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -47,6 +47,11 @@ const targets = [
     url: "https://collections.csntm.org/image-service/iiif/MNTGRCGA01/default/M_NT_GRC_GA01_20250609_203r/M_NT_GRC_GA01_20250609_203r/info.json",
   },
   {
+    name: "Austrian National Library",
+    expectedDezoomer: "IIIF",
+    url: "https://api.onb.ac.at/iiif/presentation/v3/manifest/10048A37",
+  },
+  {
     name: "Memorix TopViewer",
     expectedDezoomer: "TopViewer",
     url: "https://images.memorix.nl/wba/topviewjson/memorix/6eb5a89b-b76c-5039-3999-aabfd7a0c7c9",


### PR DESCRIPTION
## Summary
- recognize ONB viewer, direct Presentation v3 manifest, and legacy RepViewer doc URLs as IIIF inputs
- extend IIIF Presentation manifest parsing to find ImageService3 services in v3 annotation bodies
- add deterministic ONB fixtures/tests and a targeted live compatibility entry

Fixes #676

## Tests
- npm test
- npm run test:live -- -g "Austrian National Library"