### PR TITLE
iiif: read manifest URLs from fragments

### DIFF
--- a/dezoomers/iiif.js
+++ b/dezoomers/iiif.js
@@ -20,7 +20,7 @@ var iiif = (function () {
   var philadelphiaMuseumMicrioShortIdReg =
     /(?:philamuseum|Philadelphia Museum)[\s\S]*\\?"shortId\\?"\s*:\s*\\?"([A-Za-z0-9_-]{3,32})\\?"|\\?"shortId\\?"\s*:\s*\\?"([A-Za-z0-9_-]{3,32})\\?"[\s\S]*(?:philamuseum|Philadelphia Museum)/;
   var contentdmRecordReg = /^(https?:\/\/[^/]+)(\/digital)\/collection\/([^/?#]+)\/id\/(\d+)(?:[/?#]|$)/;
-  var manifestParamReg = /^https?:\/\/[^?#]+[?&][^#]*\bmanifest=/;
+  var manifestParamReg = /^https?:\/\/[^#]*(?:[?&][^#]*\bmanifest=|#[^#]*\bmanifest=)/;
   var onbPresentationManifestReg = /^https?:\/\/api\.onb\.ac\.at\/iiif\/presentation\/v3\/manifest\/[^?#]+(?:[?#].*)?$/;
   var onbViewerReg = /^https?:\/\/viewer\.onb\.ac\.at\/[^?#]+(?:[?#].*)?$/;
   var onbRepViewerReg = /^https?:\/\/digital\.onb\.ac\.at\/RepViewer\/viewer\.faces\?(?=[^#]*\bdoc=)/;
@@ -69,11 +69,17 @@ var iiif = (function () {
   }
   function manifestParamUrl(baseUrl) {
     try {
-      return new URL(baseUrl).searchParams.get("manifest");
+      var url = new URL(baseUrl);
+      return url.searchParams.get("manifest") || fragmentManifestParamUrl(url.hash);
     } catch (e) {
-      var match = String(baseUrl).match(/[?&]manifest=([^&#]+)/);
+      var match = String(baseUrl).match(/[?&#]manifest=([^&#]+)/);
       return match && decodeURIComponent(match[1]);
     }
+  }
+  function fragmentManifestParamUrl(hash) {
+    if (!hash) return null;
+    var params = String(hash).replace(/^#\??/, "");
+    return new URLSearchParams(params).get("manifest");
   }
   function onbManifestUrl(baseUrl) {
     try {

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -136,6 +136,11 @@ test.describe("dezoomer fixture coverage", () => {
       },
       {
         dezoomer: "IIIF",
+        url: "https://fixtures.test/uv/#?manifest=https%3A%2F%2Ffixtures.test%2Fiiif-presentation%2Fmanifest.json",
+        expectedTile: "/iiif/mirador/256,256,256,256/256,256/0/native.jpg",
+      },
+      {
+        dezoomer: "IIIF",
         url: "https://fixtures.test/micrio-custom-element",
         expectedTile: "https://iiif.micr.io/KEimL/256,256,256,256/256,256/0/default.jpg",
       },


### PR DESCRIPTION
## Summary
- detect IIIF manifest parameters in URL fragments such as Universal Viewer #?manifest=...
- decode fragment manifest URLs before fetching the Presentation manifest
- add deterministic automatic-selection coverage using the existing IIIF Presentation v2 fixture

## Notes
- This PR intentionally does not add IIIF Presentation v3 parsing; live British Library Universal Viewer manifests still need the ONB Presentation v3 parser work to be present as well.
- No BL live-smoke target is added here to keep this PR atomic and deterministic.

## Tests
- env NODE_PATH=/Users/ophir.lojkine/dev/dezoomify/tests/node_modules /Users/ophir.lojkine/dev/dezoomify/tests/node_modules/.bin/playwright test dezoomers.spec.js
- env NODE_PATH=/Users/ophir.lojkine/dev/dezoomify/tests/node_modules /Users/ophir.lojkine/dev/dezoomify/tests/node_modules/.bin/playwright test