### PR TITLE
Add Art Institute of Chicago artwork support

### DIFF
--- a/dezoomers/artic.js
+++ b/dezoomers/artic.js
@@ -1,0 +1,44 @@
+var artic = (function () {
+  var artworkUrlReg = /^https?:\/\/www\.artic\.edu\/artworks\/(\d+)(?:[/?#]|$)/;
+
+  function apiUrl(artworkId) {
+    return "https://api.artic.edu/api/v1/artworks/" + artworkId +
+      "?fields=id,title,image_id,thumbnail,alt_image_ids";
+  }
+
+  function open(url) {
+    var match = url.match(artworkUrlReg);
+    if (!match) throw new Error("Unsupported Art Institute of Chicago URL.");
+
+    ZoomManager.getFile(apiUrl(match[1]), { type: "json" }, function (response) {
+      var artwork = response && response.data;
+      var iiifUrl = response && response.config && response.config.iiif_url;
+      var thumbnail = artwork && artwork.thumbnail;
+      var imageId = artwork && artwork.image_id;
+
+      if (!iiifUrl || !imageId || !thumbnail || !thumbnail.width || !thumbnail.height) {
+        throw new Error("No Art Institute of Chicago IIIF image found.");
+      }
+
+      ZoomManager.readyToRender({
+        origin: iiifUrl.replace(/\/$/, "") + "/" + imageId,
+        width: parseInt(thumbnail.width),
+        height: parseInt(thumbnail.height),
+        tileSize: 1024,
+        maxZoomLevel: 1,
+        quality: "default",
+        format: "jpg"
+      });
+    });
+  }
+
+  return {
+    name: "Art Institute of Chicago",
+    description: "Artwork pages from the Art Institute of Chicago",
+    urls: [artworkUrlReg],
+    open: open,
+    getTileURL: iiif.getTileURL
+  };
+})();
+
+ZoomManager.addDezoomer(artic);

--- a/index.html
+++ b/index.html
@@ -190,6 +190,7 @@
   <script type="text/javascript" src="dezoomers/topviewer.js"></script>
   <script type="text/javascript" src="dezoomers/krpano.js"></script>
   <script type="text/javascript" src="dezoomers/iiif.js"></script>
+  <script type="text/javascript" src="dezoomers/artic.js"></script>
   <script type="text/javascript" src="dezoomers/fsi.js"></script>
   <script type="text/javascript" src="dezoomers/lizardtech.js"></script>
   <script type="text/javascript" src="dezoomers/vls.js"></script>

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -231,6 +231,27 @@ test.describe("dezoomer fixture coverage", () => {
     expect(result.tiles.at(-1).url).toContain("/iiif/v3/256,256,256,256/256,256/0/default.jpg");
   });
 
+  test("loads Art Institute of Chicago artwork pages through the public API", async ({ page }) => {
+    const result = await runDezoomer(
+      page,
+      "Select automatically",
+      "https://www.artic.edu/artworks/20684/paris-street-rainy-day"
+    );
+
+    expect(result.dezoomerName).toBe("Art Institute of Chicago");
+    expect(result.data.origin).toBe("https://www.artic.edu/iiif/2/f8fd76e9-c396-5678-36ed-6a348c904d27");
+    expect(result.data.width).toBe(9987);
+    expect(result.data.height).toBe(7755);
+    expect(result.data.tileSize).toBe(1024);
+    expect(result.tiles).toHaveLength(80);
+    expect(result.tiles.map((tile) => tile.url)).toContain(
+      "https://www.artic.edu/iiif/2/f8fd76e9-c396-5678-36ed-6a348c904d27/0,0,1024,1024/1024,1024/0/default.jpg"
+    );
+    expect(result.tiles.at(-1).url).toBe(
+      "https://www.artic.edu/iiif/2/f8fd76e9-c396-5678-36ed-6a348c904d27/9216,7168,771,587/771,587/0/default.jpg"
+    );
+  });
+
   test("generates IIIF tile URLs with explicit returned dimensions", async ({ page }) => {
     const urls = await page.evaluate(() => {
       const iiif = window.ZoomManager.dezoomersList.IIIF;

--- a/tests/fixtures/remote/api.artic.edu/api/v1/artworks/20684.json
+++ b/tests/fixtures/remote/api.artic.edu/api/v1/artworks/20684.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "id": 20684,
+    "title": "Paris Street; Rainy Day",
+    "image_id": "f8fd76e9-c396-5678-36ed-6a348c904d27",
+    "thumbnail": {
+      "width": 9987,
+      "height": 7755
+    },
+    "alt_image_ids": []
+  },
+  "config": {
+    "iiif_url": "https://www.artic.edu/iiif/2"
+  }
+}


### PR DESCRIPTION
## Summary

- add a narrow Art Institute of Chicago dezoomer for `www.artic.edu/artworks/{id}` pages
- fetch `image_id` and dimensions from the public ArtIC artwork API instead of blocked `info.json`
- reuse the existing IIIF tile URL generator and add deterministic fixture coverage for Paris Street; Rainy Day

Related: #544, #906, #911, #928, #929.

## Live reliability

I did not add ArtIC to `README.md` or `tests/live-compat.spec.js`: the public API works from this environment, but direct `www.artic.edu/iiif/2/.../info.json` and direct tile probes return Cloudflare challenge responses (`cf-mitigated: challenge`, HTTP 403).

## Tests

- `npm test`
