### PR TITLE
Fix Seadragon overlap tile placement

### DIFF
--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -255,6 +255,22 @@ test.describe("dezoomer fixture coverage", () => {
     }
   });
 
+  test("places Deep Zoom overlap only on non-edge tile axes", async ({ page }) => {
+    const result = await runDezoomer(
+      page,
+      "Seadragon (Deep Zoom Image)",
+      "https://fixtures.test/deepzoom/overlap.dzi"
+    );
+
+    expect(result.data.overlap).toBe(1);
+    expect(result.tiles.map(({ x, y }) => ({ x, y }))).toEqual([
+      { x: 0, y: 0 },
+      { x: 255, y: 0 },
+      { x: 0, y: 255 },
+      { x: 255, y: 255 },
+    ]);
+  });
+
   test("generates IIIF tile URLs with explicit returned dimensions", async ({ page }) => {
     const urls = await page.evaluate(() => {
       const iiif = window.ZoomManager.dezoomersList.IIIF;

--- a/tests/fixtures/remote/fixtures.test/deepzoom/overlap.dzi
+++ b/tests/fixtures/remote/fixtures.test/deepzoom/overlap.dzi
@@ -1,0 +1,1 @@
+<Image TileSize="256" Overlap="1" Format="jpg" xmlns="http://schemas.microsoft.com/deepzoom/2008"><Size Width="512" Height="512" /></Image>

--- a/zoommanager.js
+++ b/zoommanager.js
@@ -288,7 +288,11 @@ ZoomManager.defaultRender = function (data) {
 	function addTile(url, x, y, data) {
 		if (typeof url === "string") {
 			if (data.origin) url = ZoomManager.resolveRelative(url, data.origin);
-			ZoomManager.addTile(url, x * data.tileSize - data.overlap, y * data.tileSize - data.overlap);
+			ZoomManager.addTile(
+				url,
+				x * data.tileSize - (x > 0 ? data.overlap : 0),
+				y * data.tileSize - (y > 0 ? data.overlap : 0)
+			);
 		} else { // Promise
 			url.then(function (url) {
 				addTile(url, x, y, data)


### PR DESCRIPTION
Follow-up to merged Prado support in #950, addressing the automated review comment at https://github.com/lovasoa/dezoomify/pull/950#discussion_r3337091214.

`ZoomManager.defaultRender` previously subtracted Deep Zoom overlap from every tile coordinate, including the top row and left column. For overlapped DZI/Seadragon tiles, only non-edge tiles should be shifted on axes where the tile index is greater than zero, so tile `(0,0)` remains at `(0,0)` while adjacent tiles account for the shared overlap.

Changes:
- Make default tile placement edge-aware for `data.overlap`.
- Add a deterministic Deep Zoom fixture with `Overlap="1"` and Playwright coverage for the first four tile coordinates.

Tests:
- `npm test` from `tests/`
