### PR TITLE
restore live VLS compatibility

### DIFF
--- a/dezoomers/vls.js
+++ b/dezoomers/vls.js
@@ -11,7 +11,8 @@ var vls = (function () {
       callback(url);
     },
     open: function (url) {
-      ZoomManager.getFile(url, { type: 'xml' }, function (doc, xhr) {
+      ZoomManager.getFile(url, {}, function (text, xhr) {
+        var doc = new DOMParser().parseFromString(text, 'text/html');
         var vars = {};
         var varNodes = doc.getElementsByTagName('var');
         for (var i = 0; i < varNodes.length; i++) {

--- a/tests/fixtures/remote/fixtures.test/vls/zoom/1.html
+++ b/tests/fixtures/remote/fixtures.test/vls/zoom/1.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Visual Library fixture</title>
+  </head>
+  <body>
+    <var id="zoomTileSize" value="512"></var>
+    <map id="map" vls:ot_id="fixture" vls:width="512" vls:height="512"></map>
+  </body>
+</html>

--- a/tests/fixtures/remote/fixtures.test/vls/zoom/1.xml
+++ b/tests/fixtures/remote/fixtures.test/vls/zoom/1.xml
@@ -1,4 +1,0 @@
-<root>
-  <var id="zoomTileSize" value="512" />
-  <map id="map" vls:ot_id="fixture" vls:width="512" vls:height="512" xmlns:vls="urn:vls" />
-</root>

--- a/tests/live-compat.spec.js
+++ b/tests/live-compat.spec.js
@@ -57,6 +57,17 @@ const targets = [
     url: "https://images.memorix.nl/wba/topviewjson/memorix/6eb5a89b-b76c-5039-3999-aabfd7a0c7c9",
   },
   {
+    name: "BLB Visual Library Server",
+    expectedDezoomer: "VLS",
+    url: "https://digital.blb-karlsruhe.de/blbhs/content/zoom/2410801",
+    cookies: "js_enabled=2",
+  },
+  {
+    name: "Hungaricana postcard gallery",
+    expectedDezoomer: "Hungaricana",
+    url: "https://gallery.hungaricana.hu/en/SzerencsKepeslap/1168634/?img=0",
+  },
+  {
     name: "Oklahoma State Digital Collections",
     expectedDezoomer: "IIIF",
     url: "https://dc.library.okstate.edu/digital/collection/OKMaps/id/6483/rec/6",
@@ -191,7 +202,7 @@ async function runLiveTarget(page, target) {
         ZoomManager.data = null;
         ZoomManager.proxy_url = proxyUrl;
         ZoomManager.proxy_tiles = "";
-        ZoomManager.cookies = "";
+        ZoomManager.cookies = target.cookies || "";
         ZoomManager.nextTick = (fn) => setTimeout(fn, 0);
         ZoomManager.error = (message) => fail(new Error(message));
         ZoomManager.updateProgress = () => {};


### PR DESCRIPTION
Visual Library Server pages are now HTML rather than XML, so parse them as HTML before reading their existing VLS attributes. Add live coverage for BLB VLS and Hungaricana, including per-target cookies needed to pass BLB's JavaScript capability check.

Verified locally:
- `npm test`: 16 passed
- `npm run test:live -- --grep "BLB Visual Library Server|Hungaricana postcard gallery"`: 2 passed