### PR TITLE
Resolve known Memorix detail URLs without page fetches

### DIFF
--- a/dezoomers/topviewer.js
+++ b/dezoomers/topviewer.js
@@ -1,5 +1,32 @@
 var topviewer = (function(){
 	var memorixThumbnailRegexp = /(?:images\.memorix|afbeeldingen\.gahetna|images\.rkd)\.nl\/(.*?)\/thumb\/(?:image(?:bank)?-)?(?:[0-9x]*?(?:crop)?|detailresult|gallery_thumb|mediabank-(?:detail|horizontal))\/(.*?)\.jpg/;
+	// Institution mappings adapted from VDK/Dememorixer's beeldbanken.json (GPL-2.0):
+	// https://github.com/VDK/Dememorixer/blob/master/beeldbanken.json
+	var memorixSites = [
+		{ url: /koninklijkeverzamelingen\.nl\/(?:collectie-online|mediabank)/, imageServer: "kha" },
+		{ url: /beeldbankgroningen\.nl\/beelden/, imageServer: "gra" },
+		{ url: /rhcrijnstreek\.nl\/bronnen\/foto-s-en-kaarten\/zoeken/, imageServer: "srs" },
+		{ url: /salha\.nl\/archieven-en-collecties\/beeld\/beeldbank/, imageServer: "sha" },
+		{ url: /archief\.zaanstad\.nl\/beeldbank/, imageServer: "zaa" },
+		{ url: /regionaalarchiefzutphen\.nl\/beeld/, imageServer: "szu" },
+		{ url: /noord-hollandsarchief\.nl\/beelden\/beeldbank/, imageServer: "ranh" },
+		{ url: /nationaalarchief\.nl/, imageServer: "naa" }
+	];
+	var memorixDetailPath = "\\/detail\\/[a-z0-9-]{36}\\/media\\/([a-z0-9-]{36})";
+	var memorixDetailUrls = memorixSites.map(function (site) {
+		return new RegExp(site.url.source + memorixDetailPath, "i");
+	});
+
+	function knownMemorixFile(baseUrl) {
+		for (var i = 0; i < memorixDetailUrls.length; i++) {
+			var match = baseUrl.match(memorixDetailUrls[i]);
+			if (match) {
+				return "https://images.memorix.nl/" + memorixSites[i].imageServer +
+					"/topviewjson/memorix/" + match[1];
+			}
+		}
+		return null;
+	}
 
 	function findMediaBank(baseUrl, text, callback) {
 		var doc = new DOMParser().parseFromString(text, "text/html");
@@ -43,7 +70,7 @@ var topviewer = (function(){
 			/memorix/,
 			/rhcrijnstreek\.nl/,
 			/topview\.?json/,
-		],
+		].concat(memorixDetailUrls),
 		"contents": [
 			memorixThumbnailRegexp,
 			/<pic-mediabank\b/i,
@@ -59,6 +86,8 @@ var topviewer = (function(){
 			if (baseUrl.match(/memorix\.nl\/.+\/topviewjson\/memorix/)) {
 				return callback(baseUrl);
 			}
+			var knownFile = knownMemorixFile(baseUrl);
+			if (knownFile) return callback(knownFile);
 			ZoomManager.getFile(baseUrl, {type:"htmltext"}, function(text, xhr) {
 				if (findMediaBank(baseUrl, text, callback)) return;
 				// Memorix image thumbnail

--- a/dezoomers/topviewer.js
+++ b/dezoomers/topviewer.js
@@ -10,7 +10,7 @@ var topviewer = (function(){
 		{ url: /archief\.zaanstad\.nl\/beeldbank/, imageServer: "zaa" },
 		{ url: /regionaalarchiefzutphen\.nl\/beeld/, imageServer: "szu" },
 		{ url: /noord-hollandsarchief\.nl\/beelden\/beeldbank/, imageServer: "ranh" },
-		{ url: /nationaalarchief\.nl/, imageServer: "naa" }
+		{ url: /nationaalarchief\.nl\/onderzoeken\/fotocollectie/, imageServer: "naa" }
 	];
 	var memorixDetailPath = "\\/detail\\/[a-z0-9-]{36}\\/media\\/([a-z0-9-]{36})";
 	var memorixDetailUrls = memorixSites.map(function (site) {

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -271,6 +271,32 @@ test.describe("dezoomer fixture coverage", () => {
     }
   });
 
+  test("resolves Dememorixer institution detail URLs without fetching their pages", async ({ page }) => {
+    const record = "11111111-1111-1111-1111-111111111111";
+    const media = "22222222-2222-2222-2222-222222222222";
+    const cases = [
+      ["https://www.koninklijkeverzamelingen.nl/collectie-online", "kha"],
+      ["https://www.beeldbankgroningen.nl/beelden", "gra"],
+      ["https://rhcrijnstreek.nl/bronnen/foto-s-en-kaarten/zoeken", "srs"],
+      ["https://salha.nl/archieven-en-collecties/beeld/beeldbank", "sha"],
+      ["https://archief.zaanstad.nl/beeldbank", "zaa"],
+      ["https://regionaalarchiefzutphen.nl/beeld", "szu"],
+      ["https://noord-hollandsarchief.nl/beelden/beeldbank", "ranh"],
+      ["https://www.nationaalarchief.nl/", "naa"],
+    ];
+
+    for (const [baseUrl, imageServer] of cases) {
+      const url = `${baseUrl.replace(/\/$/, "")}/detail/${record}/media/${media}`;
+      const result = await page.evaluate((input) => new Promise((resolve) => {
+        window.ZoomManager.dezoomersList.TopViewer.findFile(input, resolve);
+      }), url);
+
+      expect(result, url).toBe(
+        `https://images.memorix.nl/${imageServer}/topviewjson/memorix/${media}`
+      );
+    }
+  });
+
   test("generates IIIF tile URLs with explicit returned dimensions", async ({ page }) => {
     const urls = await page.evaluate(() => {
       const iiif = window.ZoomManager.dezoomersList.IIIF;

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -282,16 +282,29 @@ test.describe("dezoomer fixture coverage", () => {
       ["https://archief.zaanstad.nl/beeldbank", "zaa"],
       ["https://regionaalarchiefzutphen.nl/beeld", "szu"],
       ["https://noord-hollandsarchief.nl/beelden/beeldbank", "ranh"],
-      ["https://www.nationaalarchief.nl/", "naa"],
+      ["https://www.nationaalarchief.nl/onderzoeken/fotocollectie", "naa"],
     ];
 
     for (const [baseUrl, imageServer] of cases) {
       const url = `${baseUrl.replace(/\/$/, "")}/detail/${record}/media/${media}`;
-      const result = await page.evaluate((input) => new Promise((resolve) => {
-        window.ZoomManager.dezoomersList.TopViewer.findFile(input, resolve);
-      }), url);
+      const result = await page.evaluate((input) => {
+        const ZoomManager = window.ZoomManager;
+        const automatic = ZoomManager.dezoomersList["Select automatically"];
+        const originalOpen = ZoomManager.open;
+        let selectedDezoomer;
+        ZoomManager.open = () => { selectedDezoomer = ZoomManager.dezoomer.name; };
+        automatic.open(input);
+        ZoomManager.open = originalOpen;
 
-      expect(result, url).toBe(
+        return new Promise((resolve) => {
+          ZoomManager.dezoomersList.TopViewer.findFile(input, (file) => {
+            resolve({ file, selectedDezoomer });
+          });
+        });
+      }, url);
+
+      expect(result.selectedDezoomer, url).toBe("TopViewer");
+      expect(result.file, url).toBe(
         `https://images.memorix.nl/${imageServer}/topviewjson/memorix/${media}`
       );
     }


### PR DESCRIPTION
# resolve known Memorix detail URLs without page fetches

Some Memorix institution pages block the hosted proxy, but their detail URLs already contain the media UUID.

[`topviewer.js`](https://github.com/lovasoa/dezoomify/blob/ophir.lojkine/anubis-metarefresh/dezoomers/topviewer.js) now includes the institution-to-image-server mappings from [VDK/Dememorixer `beeldbanken.json`](https://github.com/VDK/Dememorixer/blob/master/beeldbanken.json), with attribution, and resolves matching `/detail/<record>/media/<asset>` URLs directly to TopViewer metadata. Gallery URLs without a media UUID keep the existing discovery path.

Verified:

- `cd tests && npm test`: 18 passed, including all eight imported mappings and the exact #976 URL.
- `cd tests && npm run test:live -- --grep "Beeldbank Groningen"`: 1 passed.
- [Cloudflare preview](https://35d51b45.dezoomify.pages.dev) with the exact #976 URL selected TopViewer, loaded `3237x2082` metadata and a `256px` tile. Its only proxy request was the direct `images.memorix.nl/gra/topviewjson/...` URL; it never requested the protected institution page.

This directly fixes detail URLs such as #976. Gallery URLs such as #975 do not contain a media UUID and are intentionally unchanged. The prior Anubis/refresh implementation was removed from this branch.