### PR TITLE
Support cached ArcGIS MapServer services

### DIFF
--- a/dezoomers/arcgis.js
+++ b/dezoomers/arcgis.js
@@ -1,0 +1,149 @@
+function isArcGISMapServerUrl(url) {
+  try {
+    return /\/MapServer\/?$/i.test(new URL(url).pathname);
+  } catch (_error) {
+    return false;
+  }
+}
+
+function normalizeArcGISMapServerUrl(url) {
+  const service = new URL(url);
+  const match = service.pathname.match(/^(.*\/MapServer)\/?$/i);
+  if (!match) throw new Error("Expected an ArcGIS MapServer URL.");
+
+  service.pathname = match[1];
+  const tileParameters = new URLSearchParams(service.search);
+  for (const name of [...tileParameters.keys()]) {
+    if (name.toLowerCase() === "f") tileParameters.delete(name);
+  }
+  service.search = "";
+
+  const metadata = new URL(service);
+  metadata.search = tileParameters;
+  metadata.searchParams.set("f", "json");
+
+  return {
+    serviceUrl: service.toString(),
+    metadataUrl: metadata.toString(),
+    tileParameters: tileParameters.toString(),
+  };
+}
+
+function number(value, name) {
+  if (!Number.isFinite(value)) throw new Error(`Invalid ArcGIS MapServer ${name}.`);
+  return value;
+}
+
+function matchingSpatialReferences(first, second) {
+  if (!first || !second) return false;
+  const firstId = first.latestWkid || first.wkid || first.wkt;
+  const secondId = second.latestWkid || second.wkid || second.wkt;
+  return firstId != null && secondId != null && firstId === secondId;
+}
+
+function tileMatrices(metadata, service) {
+  if (metadata.type !== "MapServer") {
+    throw new Error("ArcGIS service is not a MapServer.");
+  }
+  if (!metadata.singleFusedMapCache) {
+    throw new Error("ArcGIS MapServer does not provide a fused tile cache.");
+  }
+
+  const tileInfo = metadata.tileInfo;
+  const extent = metadata.fullExtent;
+  if (!tileInfo || !extent || !Array.isArray(tileInfo.lods)) {
+    throw new Error("ArcGIS MapServer is missing cached tile metadata.");
+  }
+  if (!matchingSpatialReferences(tileInfo.spatialReference, extent.spatialReference)) {
+    throw new Error("ArcGIS MapServer tile cache and extent use different spatial references.");
+  }
+
+  const tileWidth = number(tileInfo.cols, "tile width");
+  const tileHeight = number(tileInfo.rows, "tile height");
+  if (tileWidth <= 0 || tileHeight <= 0 || tileWidth !== tileHeight) {
+    throw new Error("ArcGIS MapServer must use square cached tiles.");
+  }
+  const originX = number(tileInfo.origin && tileInfo.origin.x, "tile origin x");
+  const originY = number(tileInfo.origin && tileInfo.origin.y, "tile origin y");
+  const xmin = number(extent.xmin, "extent xmin");
+  const ymin = number(extent.ymin, "extent ymin");
+  const xmax = number(extent.xmax, "extent xmax");
+  const ymax = number(extent.ymax, "extent ymax");
+  if (xmin > xmax || ymin > ymax) throw new Error("Invalid ArcGIS MapServer extent.");
+
+  return tileInfo.lods.map((lod) => {
+    const resolution = number(lod.resolution, "LOD resolution");
+    const level = number(lod.level, "LOD level");
+    if (resolution <= 0) throw new Error("Invalid ArcGIS MapServer LOD resolution.");
+
+    const spanX = tileWidth * resolution;
+    const spanY = tileHeight * resolution;
+    const minColumn = Math.floor((xmin - originX) / spanX);
+    const maxColumn = Math.floor((xmax - originX) / spanX);
+    const minRow = Math.floor((originY - ymax) / spanY);
+    const maxRow = Math.floor((originY - ymin) / spanY);
+    const nbrTilesX = maxColumn - minColumn + 1;
+    const nbrTilesY = maxRow - minRow + 1;
+
+    return {
+      serviceUrl: service.serviceUrl,
+      tileParameters: service.tileParameters,
+      level,
+      resolution,
+      tileSize: tileWidth,
+      width: nbrTilesX * tileWidth,
+      height: nbrTilesY * tileHeight,
+      nbrTilesX,
+      nbrTilesY,
+      minColumn,
+      maxColumn,
+      minRow,
+      maxRow,
+      maxZoomLevel: 1,
+    };
+  });
+}
+
+ZoomManager.addDezoomer({
+  name: "ArcGIS MapServer",
+  description: "Cached ArcGIS REST MapServer",
+  urls: [/(?:\/|%2f)MapServer(?:\/|%2f|%3f|%26|[?&#]|$)/i],
+  findFile(baseUrl, callback) {
+    const viewerUrl = new URL(baseUrl);
+    const basemapUrl = viewerUrl.searchParams.get("basemapUrl");
+    callback(basemapUrl && isArcGISMapServerUrl(basemapUrl) ? basemapUrl : baseUrl);
+  },
+  open(url) {
+    let service;
+    try {
+      service = normalizeArcGISMapServerUrl(url);
+    } catch (error) {
+      ZoomManager.error(error.message);
+      return;
+    }
+
+    ZoomManager.getFile(service.metadataUrl, { type: "json" }, (metadata) => {
+      try {
+        const matrix = tileMatrices(metadata, service)
+          .filter((candidate) => candidate.width * candidate.height < UI.MAX_CANVAS_AREA)
+          .sort((first, second) => first.resolution - second.resolution)[0];
+        if (!matrix) throw new Error("No ArcGIS MapServer level fits within the canvas limit.");
+        ZoomManager.readyToRender(matrix);
+      } catch (error) {
+        ZoomManager.error(error.message);
+      }
+    });
+  },
+  getTileURL(x, y, _zoom, matrix) {
+    const column = matrix.minColumn + x;
+    const row = matrix.minRow + y;
+    if (
+      column < matrix.minColumn || column > matrix.maxColumn ||
+      row < matrix.minRow || row > matrix.maxRow
+    ) {
+      throw new Error(`Invalid ArcGIS tile coordinates at ${x}, ${y}.`);
+    }
+    const url = `${matrix.serviceUrl}/tile/${matrix.level}/${row}/${column}`;
+    return matrix.tileParameters ? `${url}?${matrix.tileParameters}` : url;
+  },
+});

--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
   <script type="text/javascript" src="dezoomers/vls.js"></script>
   <script type="module" src="dezoomers/arts-culture.js"></script>
   <script type="module" src="dezoomers/hungaricana.js"></script>
+  <script type="module" src="dezoomers/arcgis.js"></script>
   <script type="module" src="dezoomers/wmts.js"></script>
   <script type="module" src="dezoomers/pnav.js"></script>
   <script type="text/javascript" src="dezoomers/generic.js"></script>

--- a/tests/dezoomers.spec.js
+++ b/tests/dezoomers.spec.js
@@ -205,6 +205,11 @@ test.describe("dezoomer fixture coverage", () => {
         expectedTile: "/wmts/EPSG3857/0/10/10.jpg",
       },
       {
+        dezoomer: "ArcGIS MapServer",
+        url: "https://fixtures.test/arcgis/MapServer",
+        expectedTile: "/arcgis/MapServer/tile/7/3/4",
+      },
+      {
         dezoomer: "pnav",
         url: "https://fixtures.test/entity/OBJECT/1",
         expectedTile: "/fixtures/pnav/image.jpg?w=2000&h=2000&cl=0&ct=0&cw=512&ch=512",
@@ -229,6 +234,36 @@ test.describe("dezoomer fixture coverage", () => {
     expect(result.data.quality).toBe("default");
     expect(result.data.format).toBe("jpg");
     expect(result.tiles.at(-1).url).toContain("/iiif/v3/256,256,256,256/256,256/0/default.jpg");
+  });
+
+  test("discovers cached ArcGIS MapServer viewer URLs and uses global row/column coordinates", async ({ page }) => {
+    const serviceUrl = "https://fixtures.test/arcgis/MapServer?token=fixture&f=html";
+    const viewerUrl = `https://wmts.ngi.be/arcgis/home/webmap/viewer.html?basemapUrl=${encodeURIComponent(serviceUrl)}`;
+    const result = await runDezoomer(page, "Select automatically", viewerUrl);
+
+    expect(result.dezoomerName).toBe("ArcGIS MapServer");
+    expect(result.data.width).toBe(768);
+    expect(result.data.height).toBe(768);
+    expect(result.data.minColumn).toBe(2);
+    expect(result.data.minRow).toBe(1);
+    expect(result.tiles[0].url).toBe(
+      "https://fixtures.test/arcgis/MapServer/tile/7/1/2?token=fixture"
+    );
+    expect(result.tiles[1].url).toBe(
+      "https://fixtures.test/arcgis/MapServer/tile/7/1/3?token=fixture"
+    );
+    expect(result.tiles[3].url).toBe(
+      "https://fixtures.test/arcgis/MapServer/tile/7/2/2?token=fixture"
+    );
+    expect(result.tiles.every(({ url }) => !url.includes("f="))).toBe(true);
+  });
+
+  test("rejects uncached ArcGIS MapServer responses", async ({ page }) => {
+    await expect(runDezoomer(
+      page,
+      "ArcGIS MapServer",
+      "https://fixtures.test/arcgis/uncached/MapServer"
+    )).rejects.toThrow("does not provide a fused tile cache");
   });
 
   test("discovers ONB IIIF Presentation 3 manifests", async ({ page }) => {

--- a/tests/fixture-server.js
+++ b/tests/fixture-server.js
@@ -118,6 +118,13 @@ function fixturePathFor(url) {
   }
 
   if (url.hostname === "fixtures.test") {
+    if (url.pathname === "/arcgis/MapServer") {
+      if (url.searchParams.get("f") === "json") {
+        return fixtureFile(url.hostname, "/arcgis/MapServer.json");
+      }
+      return null;
+    }
+
     if (url.pathname === "/iip" && url.searchParams.has("OBJ")) {
       return fixtureFile(url.hostname, "/iip/image-info.txt");
     }

--- a/tests/fixtures/remote/fixtures.test/arcgis/MapServer.json
+++ b/tests/fixtures/remote/fixtures.test/arcgis/MapServer.json
@@ -1,0 +1,21 @@
+{
+  "type": "MapServer",
+  "singleFusedMapCache": true,
+  "tileInfo": {
+    "rows": 256,
+    "cols": 256,
+    "format": "JPEG",
+    "origin": { "x": -1000, "y": 1000 },
+    "spatialReference": { "wkid": 3857 },
+    "lods": [
+      { "level": 7, "resolution": 1 }
+    ]
+  },
+  "fullExtent": {
+    "xmin": -300,
+    "ymin": 100,
+    "xmax": 200,
+    "ymax": 600,
+    "spatialReference": { "wkid": 3857 }
+  }
+}

--- a/tests/fixtures/remote/fixtures.test/arcgis/uncached/MapServer.json
+++ b/tests/fixtures/remote/fixtures.test/arcgis/uncached/MapServer.json
@@ -1,0 +1,4 @@
+{
+  "type": "MapServer",
+  "singleFusedMapCache": false
+}


### PR DESCRIPTION
Closes #987\n\nAdds a dedicated ArcGIS REST MapServer dezoomer that requests JSON metadata, computes cached tile ranges from the cache origin and full extent, and generates level/row/column tile URLs.\n\nIncludes deterministic fixtures covering automatic Cartesius-style viewer detection ahead of WMTS, metadata JSON requests, non-zero global offsets, row/column ordering, and uncached-service rejection.\n\nTests: 
> dezoomify-tests@1.0.0 test
> playwright test


Running 20 tests using 2 workers

  ✓   1 proxy-function.spec.js:11:3 › Cloudflare Pages proxy function › proxies GET and HEAD requests on the proxy route (9ms)
Requested: data:text/plain,node
  ✓   3 proxy-function.spec.js:30:3 › Node proxy adapter › proxies through the shared handler (85ms)
  ✓   2 dezoomers.spec.js:100:3 › dezoomer fixture coverage › loads core zoomable formats from deterministic fixtures (789ms)
  ✓   4 dezoomers.spec.js:229:3 › dezoomer fixture coverage › supports IIIF Image API 3 info.json responses (114ms)
  ✓   5 dezoomers.spec.js:239:3 › dezoomer fixture coverage › discovers cached ArcGIS MapServer viewer URLs and uses global row/column coordinates (72ms)
  ✓   6 dezoomers.spec.js:261:3 › dezoomer fixture coverage › rejects uncached ArcGIS MapServer responses (49ms)
  ✓   7 dezoomers.spec.js:269:3 › dezoomer fixture coverage › discovers ONB IIIF Presentation 3 manifests (72ms)
  ✓   8 dezoomers.spec.js:288:3 › dezoomer fixture coverage › places Deep Zoom overlap only on non-edge tile axes (53ms)
  ✓   9 dezoomers.spec.js:304:3 › dezoomer fixture coverage › discovers images from current Memorix mediabank pages (60ms)
  ✓  10 dezoomers.spec.js:319:3 › dezoomer fixture coverage › resolves Dememorixer institution detail URLs without fetching their pages (53ms)
  ✓  11 dezoomers.spec.js:358:3 › dezoomer fixture coverage › generates IIIF tile URLs with explicit returned dimensions (47ms)
  ✓  12 dezoomers.spec.js:382:3 › dezoomer fixture coverage › keeps Zoomify full-resolution-only NUMTILES in TileGroup0 (1.2s)
  ✓  13 dezoomers.spec.js:399:3 › dezoomer fixture coverage › ignores internal IIIF ids and uses the public info.json base (55ms)
  ✓  14 dezoomers.spec.js:410:3 › dezoomer fixture coverage › uses the info.json origin when IIIF metadata has a same-host default port (52ms)
  ✓  15 dezoomers.spec.js:421:3 › dezoomer fixture coverage › discovers CONTENTdm IIIF info URLs through the API (53ms)
  ✓  16 dezoomers.spec.js:435:3 › dezoomer fixture coverage › rejects IIIF Presentation manifests with only plain images (49ms)
  ✓  17 dezoomers.spec.js:443:3 › dezoomer fixture coverage › extracts current National Gallery IIIF URLs from pages (53ms)
  ✓  18 dezoomers.spec.js:455:3 › dezoomer fixture coverage › extracts London Museum bare IIIF service roots from pages (54ms)
  ✓  19 dezoomers.spec.js:465:3 › dezoomer fixture coverage › extracts Prado OpenSeadragon metadata from artwork pages (476ms)
  ✓  20 dezoomers.spec.js:486:3 › dezoomer fixture coverage › extracts Philadelphia Museum Micrio short IDs as IIIF info URLs (65ms)

  20 passed (3.8s)