### PR TITLE
Add Gigapan image support

### DIFF
--- a/apps/cli/src/arguments.rs
+++ b/apps/cli/src/arguments.rs
@@ -431,6 +431,7 @@ pub fn known_dezoomers() -> &'static [&'static str] {
         "custom",
         "google_arts_and_culture",
         "zoomify",
+        "gigapan",
         "iiif",
         "deepzoom",
         "generic",

--- a/crates/dezoomify-core/src/core/registry.rs
+++ b/crates/dezoomify-core/src/core/registry.rs
@@ -2,8 +2,8 @@
 
 use super::discovery::{DezoomerSpec, DiscoveryLimits, DiscoveryOperation};
 use crate::{
-    arcgis, bulk_text, custom_yaml, dzi, fsi, generic, google_arts_and_culture, hungaricana, iiif,
-    iipimage, krpano, lizardtech, pnav, topviewer, vls, wmts, xlimage, zoomify,
+    arcgis, bulk_text, custom_yaml, dzi, fsi, generic, gigapan, google_arts_and_culture,
+    hungaricana, iiif, iipimage, krpano, lizardtech, pnav, topviewer, vls, wmts, xlimage, zoomify,
 };
 
 /// Every built-in dezoomer, in candidate priority order.
@@ -11,6 +11,7 @@ const BUILTINS: &[DezoomerSpec] = &[
     custom_yaml::SPEC,
     google_arts_and_culture::SPEC,
     zoomify::SPEC,
+    gigapan::SPEC,
     iiif::SPEC,
     dzi::SPEC,
     generic::SPEC,
@@ -170,6 +171,7 @@ mod tests {
                 ("custom", "Custom tiles"),
                 ("google_arts_and_culture", "Arts & Culture"),
                 ("zoomify", "Zoomify"),
+                ("gigapan", "Gigapan"),
                 ("iiif", "IIIF"),
                 ("deepzoom", "Seadragon (Deep Zoom Image)"),
                 ("generic", "Generic dezoomer"),
@@ -221,6 +223,10 @@ mod tests {
             preferred_name("x/TileGroup0/0-0-0.jpg").map(DezoomerSpec::name),
             Some("zoomify")
         );
+        assert_eq!(
+            preferred_name("https://gigapan.com/gigapans/116906/").map(DezoomerSpec::name),
+            Some("gigapan")
+        );
     }
 
     #[test]
@@ -242,6 +248,10 @@ mod tests {
         assert_eq!(classify_url("x/info.json"), Some("iiif"));
         assert_eq!(classify_url("server?fif=image.tif"), Some("iipimage"));
         assert_eq!(classify_url("x/TileGroup0/0-0-0.jpg"), Some("zoomify"));
+        assert_eq!(
+            classify_url("https://gigapan.com/gigapans/116906/"),
+            Some("gigapan")
+        );
         assert_eq!(classify_url("https://example.test/unknown"), None);
     }
 

--- a/crates/dezoomify-core/src/gigapan/mod.rs
+++ b/crates/dezoomify-core/src/gigapan/mod.rs
@@ -1,0 +1,291 @@
+//! Pure discovery for Gigapan panorama pages and KML metadata.
+
+use std::sync::LazyLock;
+
+use regex::bytes::Regex as BytesRegex;
+use serde::Deserialize;
+use url::Url;
+
+use crate::Vec2d;
+use crate::core::{
+    CatalogEntry, DezoomerSpec, DiscoveryError, DiscoveryMatch, Grid, ImageCatalog,
+    ImageDescriptor, LevelDescriptor, Request, StableId,
+};
+
+const TILE_SIZE: u32 = 256;
+
+static PAGE_METADATA: LazyLock<BytesRegex> = LazyLock::new(|| {
+    BytesRegex::new(r"(?s)\bvar\s+gigapan\s*=\s*(?P<json>\{.*?\})\s*;")
+        .expect("constant Gigapan page metadata pattern")
+});
+
+const ROUTES: &[crate::core::DiscoveryRoute] =
+    &[DiscoveryMatch::ContentPredicate(contains_metadata).extract(catalog)];
+
+pub const SPEC: DezoomerSpec = DezoomerSpec::new("gigapan", ROUTES)
+    .with_display_name("Gigapan")
+    .recognizing(is_gigapan_url, "not a Gigapan URL")
+    .preferring(is_gigapan_url);
+
+fn is_gigapan_url(uri: &str) -> bool {
+    let Ok(url) = Url::parse(uri) else {
+        return false;
+    };
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    if !host.eq_ignore_ascii_case("gigapan.com") && !host.eq_ignore_ascii_case("www.gigapan.com") {
+        return false;
+    }
+    let path = url.path().trim_end_matches('/');
+    let Some(id) = path.strip_prefix("/gigapans/") else {
+        return false;
+    };
+    let id = id.strip_suffix(".kml").unwrap_or(id);
+    !id.is_empty() && id.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn contains_metadata(bytes: &[u8]) -> bool {
+    PAGE_METADATA.is_match(bytes)
+        || bytes
+            .windows(b"<ImagePyramid".len())
+            .any(|window| window.eq_ignore_ascii_case(b"<ImagePyramid"))
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GigapanMetadata {
+    id: u32,
+    width: u32,
+    height: u32,
+    #[serde(default)]
+    levels: Option<u32>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    tile_size: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PageEnvelope {
+    gigapan: GigapanMetadata,
+}
+
+#[derive(Debug, Deserialize)]
+struct KmlRoot {
+    #[serde(rename = "Document")]
+    document: KmlDocument,
+}
+
+#[derive(Debug, Deserialize)]
+struct KmlDocument {
+    #[serde(rename = "PhotoOverlay")]
+    photo_overlay: KmlPhotoOverlay,
+}
+
+#[derive(Debug, Deserialize)]
+struct KmlPhotoOverlay {
+    name: Option<String>,
+    #[serde(rename = "ImagePyramid")]
+    image_pyramid: KmlImagePyramid,
+    #[serde(rename = "@id", default)]
+    id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KmlImagePyramid {
+    #[serde(rename = "tileSize")]
+    tile_size: u32,
+    #[serde(rename = "maxWidth")]
+    max_width: u32,
+    #[serde(rename = "maxHeight")]
+    max_height: u32,
+}
+
+fn catalog(uri: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
+    let metadata = parse_metadata(bytes)?;
+    if metadata.id == 0 {
+        return Err(DiscoveryError::Session(
+            "Gigapan id must be positive".into(),
+        ));
+    }
+    if metadata.width == 0 || metadata.height == 0 {
+        return Err(DiscoveryError::Session(
+            "Gigapan image dimensions must be positive".into(),
+        ));
+    }
+    let tile_size = metadata.tile_size.unwrap_or(TILE_SIZE);
+    if tile_size == 0 {
+        return Err(DiscoveryError::Session(
+            "Gigapan tile size must be positive".into(),
+        ));
+    }
+    let levels = metadata
+        .levels
+        .unwrap_or_else(|| level_count(metadata.width, metadata.height, tile_size).unwrap_or(1));
+    if levels == 0 || levels > 32 {
+        return Err(DiscoveryError::Session(
+            "Gigapan level count is out of range".into(),
+        ));
+    }
+    let origin = Url::parse(uri)
+        .map_err(|_| DiscoveryError::Session("invalid Gigapan metadata URL".into()))?
+        .origin()
+        .ascii_serialization();
+    let levels = build_levels(
+        metadata.id,
+        metadata.width,
+        metadata.height,
+        tile_size,
+        levels,
+        &origin,
+    )?;
+    Ok(ImageCatalog::new([CatalogEntry::Ready(ImageDescriptor {
+        id: StableId::new(format!("gigapan:{}", metadata.id)),
+        title: metadata
+            .name
+            .filter(|name| !name.trim().is_empty())
+            .map(|name| name.trim().to_owned()),
+        format: StableId::new("gigapan"),
+        levels,
+        ..Default::default()
+    })]))
+}
+
+fn parse_metadata(bytes: &[u8]) -> Result<GigapanMetadata, DiscoveryError> {
+    if let Some(captures) = PAGE_METADATA.captures(bytes) {
+        let json = captures.name("json").expect("Gigapan JSON capture");
+        let envelope: PageEnvelope = serde_json::from_slice(json.as_bytes()).map_err(|error| {
+            DiscoveryError::Session(format!("unable to parse Gigapan page metadata: {error}"))
+        })?;
+        return Ok(envelope.gigapan);
+    }
+    let kml: KmlRoot = serde_xml_rs::from_reader(bytes).map_err(|error| {
+        DiscoveryError::Session(format!("unable to parse Gigapan KML metadata: {error}"))
+    })?;
+    let overlay = kml.document.photo_overlay;
+    let id = overlay
+        .id
+        .as_deref()
+        .and_then(|id| id.strip_prefix("gigapan_"))
+        .and_then(|id| id.parse().ok())
+        .ok_or_else(|| DiscoveryError::Session("Gigapan KML has no numeric id".into()))?;
+    Ok(GigapanMetadata {
+        id,
+        width: overlay.image_pyramid.max_width,
+        height: overlay.image_pyramid.max_height,
+        levels: None,
+        name: overlay.name,
+        tile_size: Some(overlay.image_pyramid.tile_size),
+    })
+}
+
+fn level_count(width: u32, height: u32, tile_size: u32) -> Option<u32> {
+    let tiles = width.div_ceil(tile_size).max(height.div_ceil(tile_size));
+    Some(tiles.checked_next_power_of_two()?.ilog2() + 1)
+}
+
+fn build_levels(
+    id: u32,
+    width: u32,
+    height: u32,
+    tile_size: u32,
+    level_count: u32,
+    origin: &str,
+) -> Result<Vec<LevelDescriptor>, DiscoveryError> {
+    (0..level_count)
+        .map(|level| {
+            let shift = level_count - level - 1;
+            let scale = 1_u32.checked_shl(shift).ok_or_else(|| {
+                DiscoveryError::Session("Gigapan level scale is out of range".into())
+            })?;
+            let size = Vec2d {
+                x: width.div_ceil(scale),
+                y: height.div_ceil(scale),
+            };
+            let base = origin.to_owned();
+            let source = Grid::with_requests(
+                StableId::new(format!("gigapan:{id}:{level}")),
+                size,
+                Vec2d::square(tile_size),
+                Vec2d::default(),
+                move |tile| {
+                    Request::new(format!(
+                        "{base}/get_ge_tile/{id}/{level}/{}/{}",
+                        tile.coord.row, tile.coord.column
+                    ))
+                },
+            )
+            .map_err(|error| DiscoveryError::Session(format!("invalid Gigapan grid: {error}")))?;
+            Ok(LevelDescriptor::new(source).with_title(Some(format!("Gigapan level {level}"))))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{CatalogEntry, ResourceResponse, TileSource};
+
+    const PAGE: &[u8] = br#"
+        <script>
+        var gigapan = {"gigapan":{"id":116906,"name":"Machu Picchu","width":206996,"height":77069,"levels":11}};
+        </script>
+    "#;
+
+    const KML: &[u8] = br#"<?xml version="1.0"?>
+        <kml xmlns="http://www.opengis.net/kml/2.2"><Document><PhotoOverlay id="gigapan_116906"><name>Machu Picchu</name>
+        <ImagePyramid><tileSize>256</tileSize><maxWidth>206996</maxWidth><maxHeight>77069</maxHeight></ImagePyramid>
+        </PhotoOverlay></Document></kml>"#;
+
+    fn discover(uri: &str, bytes: &[u8]) -> ImageDescriptor {
+        let mut operation = crate::core::Registry::new();
+        operation.register(SPEC);
+        let mut operation = operation.start(uri);
+        let need = operation.missing_resources().unwrap().pop().unwrap();
+        operation
+            .provide(ResourceResponse::new(need.id, bytes))
+            .unwrap();
+        let catalog = operation.finish().unwrap();
+        let CatalogEntry::Ready(image) = catalog.entries().first().unwrap() else {
+            panic!("Gigapan metadata must produce a ready image")
+        };
+        image.clone()
+    }
+
+    #[test]
+    fn page_metadata_builds_full_resolution_tiles() {
+        let image = discover("https://gigapan.com/gigapans/116906/", PAGE);
+        assert_eq!(image.format.as_str(), "gigapan");
+        assert_eq!(image.title.as_deref(), Some("Machu Picchu"));
+        assert_eq!(image.levels.len(), 11);
+        let level = image.levels.last().unwrap();
+        let TileSource::Grid(grid) = &level.source else {
+            panic!("Gigapan levels must be grids")
+        };
+        assert_eq!(
+            grid.image_size(),
+            Vec2d {
+                x: 206_996,
+                y: 77_069
+            }
+        );
+        assert_eq!(grid.shape(), Vec2d { x: 809, y: 302 });
+        let tiles: Vec<_> = grid.tiles_row_major().collect::<Result<_, _>>().unwrap();
+        assert_eq!(
+            tiles.first().unwrap().request.uri,
+            "https://gigapan.com/get_ge_tile/116906/10/0/0"
+        );
+        assert_eq!(
+            tiles.last().unwrap().request.uri,
+            "https://gigapan.com/get_ge_tile/116906/10/301/808"
+        );
+    }
+
+    #[test]
+    fn kml_metadata_computes_levels_and_accepts_kml_urls() {
+        let image = discover("https://gigapan.com/gigapans/116906.kml", KML);
+        assert_eq!(image.levels.len(), 11);
+        assert!(is_gigapan_url("https://www.gigapan.com/gigapans/116906/"));
+        assert!(!is_gigapan_url("https://example.test/gigapans/116906/"));
+    }
+}

--- a/crates/dezoomify-core/src/lib.rs
+++ b/crates/dezoomify-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod custom_yaml;
 pub mod dzi;
 pub mod fsi;
 pub mod generic;
+pub mod gigapan;
 pub mod google_arts_and_culture;
 pub mod hungaricana;
 pub mod iiif;

--- a/crates/dezoomify-core/tests/parity.rs
+++ b/crates/dezoomify-core/tests/parity.rs
@@ -77,6 +77,14 @@ fn automatic_discovery_selects_every_ready_format() {
             "zoomify",
         ),
         (
+            "https://gigapan.com/gigapans/116906/",
+            &[ (
+                "https://gigapan.com/gigapans/116906/",
+                br#"<script>var gigapan = {"gigapan":{"id":116906,"name":"Machu Picchu","width":206996,"height":77069,"levels":11}};</script>"#,
+            ) ],
+            "gigapan",
+        ),
+        (
             "https://fixtures.test/iiif/info.json",
             &[ (
                 "https://fixtures.test/iiif/info.json",

--- a/crates/dezoomify-protocol/src/dto.rs
+++ b/crates/dezoomify-protocol/src/dto.rs
@@ -172,11 +172,12 @@ pub const DIRECT_TRANSPORT_LABEL: &str = "Direct from your browser";
 pub const PROXY_TRANSPORT_LABEL: &str = "Metadata proxy";
 
 /// Format grid in registry precedence order: (id, display name).
-/// Mirrors `dezoomify-core/src/core/registry.rs` BUILTINS snapshot (18 entries).
+/// Mirrors `dezoomify-core/src/core/registry.rs` BUILTINS snapshot (19 entries).
 pub const FORMAT_GRID: &[(&str, &str)] = &[
     ("custom", "Custom tiles"),
     ("google_arts_and_culture", "Arts & Culture"),
     ("zoomify", "Zoomify"),
+    ("gigapan", "Gigapan"),
     ("iiif", "IIIF"),
     ("deepzoom", "Seadragon (Deep Zoom Image)"),
     ("generic", "Generic dezoomer"),

--- a/crates/dezoomify-protocol/tests/golden.rs
+++ b/crates/dezoomify-protocol/tests/golden.rs
@@ -230,9 +230,9 @@ fn limits_grid_transports_single_generation() {
     // Transport labels stay single-sourced with browser-runtime types.ts.
     assert_eq!(DIRECT_TRANSPORT_LABEL, "Direct from your browser");
     assert_eq!(PROXY_TRANSPORT_LABEL, "Metadata proxy");
-    // Format grid mirrors registry.rs BUILTINS snapshot: 18 entries in
+    // Format grid mirrors registry.rs BUILTINS snapshot: 19 entries in
     // precedence order, with custom and bulk_text as power-user entries.
-    assert_eq!(FORMAT_GRID.len(), 18);
+    assert_eq!(FORMAT_GRID.len(), 19);
     assert_eq!(FORMAT_GRID.first(), Some(&("custom", "Custom tiles")));
     assert_eq!(FORMAT_GRID.last(), Some(&("bulk_text", "Bulk text")));
     assert_eq!(POWER_USER_FORMATS, &["custom", "bulk_text"]);
@@ -249,6 +249,7 @@ fn limits_grid_transports_single_generation() {
             "custom",
             "google_arts_and_culture",
             "zoomify",
+            "gigapan",
             "iiif",
             "deepzoom",
             "generic",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -70,6 +70,7 @@ formats](user/supported-formats.md) for what to paste per format.
 | Format | Website | Extension | Desktop app | CLI |
 |---|---|---|---|---|
 | Zoomify | Yes | Yes | Yes | Yes |
+| Gigapan | Yes | Yes | Yes | Yes |
 | Deep Zoom (Seadragon) | Yes | Yes | Yes | Yes |
 | IIIF | Yes | Yes | Yes | Yes |
 | Arts and Culture | Yes | Yes | Yes | Yes |

--- a/docs/user/finding-the-image-address.md
+++ b/docs/user/finding-the-image-address.md
@@ -28,9 +28,9 @@ in there.
 3. With the log open, **reload the page** (F5) and zoom into the image.
 4. The log fills with rows, one per file. Look for a small file, usually a
    few kilobytes, whose name ends in `.json`, `.xml`, or `.dzi`. Common
-   names are `info.json` (IIIF), `ImageProperties.xml` (Zoomify), and
-   anything ending in `.dzi` (Deep Zoom). Tiles are the big files; ignore
-   them.
+   names are `info.json` (IIIF), `ImageProperties.xml` (Zoomify), a
+   Gigapan `.kml` file, and anything ending in `.dzi` (Deep Zoom). Tiles are
+   the big files; ignore them.
 5. Right-click that row, choose *Copy → Copy URL*, and paste the address
    into Dezoomify.
 

--- a/docs/user/supported-formats.md
+++ b/docs/user/supported-formats.md
@@ -16,6 +16,7 @@ for how to find that file.
 | Format | Used by | What you can paste |
 |---|---|---|
 | Zoomify | Many museums and libraries | The viewer page, `ImageProperties.xml`, or any tile address |
+| Gigapan | Gigapan panoramic images | The Gigapan viewer page or its `.kml` metadata file |
 | Deep Zoom (Seadragon) | Microsoft-style viewers, many digital libraries | The viewer page or the `.dzi` file |
 | IIIF | Widely used by national and university libraries | A viewer page, an `info.json` file, or a presentation manifest for whole books |
 | Arts & Culture | Google Arts & Culture | The artwork page |

--- a/packages/protocol-ts/fingerprints.json
+++ b/packages/protocol-ts/fingerprints.json
@@ -1,5 +1,5 @@
 {
   "dto": "b4bad92b24615c58",
-  "limits": "e820104e045e218d",
+  "limits": "df9bb37ab989d644",
   "protocol": "1.0"
 }

--- a/packages/protocol-ts/src/generated.ts
+++ b/packages/protocol-ts/src/generated.ts
@@ -1,11 +1,11 @@
 // DO NOT EDIT: generated from crates/dezoomify-protocol/src/dto.rs
 // fingerprint: b4bad92b24615c58
-// limits-fingerprint: e820104e045e218d
+// limits-fingerprint: df9bb37ab989d644
 // protocol: 1.0
 
 export const PROTOCOL_VERSION = "1.0" as const;
 export const DTO_FINGERPRINT = "b4bad92b24615c58" as const;
-export const LIMITS_FINGERPRINT = "e820104e045e218d" as const;
+export const LIMITS_FINGERPRINT = "df9bb37ab989d644" as const;
 
 export const MAX_BROWSER_AREA = 268435456 as const;
 export const NATIVE_MAX_BYTES = 8589934592 as const;
@@ -19,6 +19,7 @@ export const FORMAT_GRID = [
   { id: "custom", displayName: "Custom tiles", powerUser: true },
   { id: "google_arts_and_culture", displayName: "Arts & Culture", powerUser: false },
   { id: "zoomify", displayName: "Zoomify", powerUser: false },
+  { id: "gigapan", displayName: "Gigapan", powerUser: false },
   { id: "iiif", displayName: "IIIF", powerUser: false },
   { id: "deepzoom", displayName: "Seadragon (Deep Zoom Image)", powerUser: false },
   { id: "generic", displayName: "Generic dezoomer", powerUser: false },

--- a/packages/protocol-ts/test/golden.test.mjs
+++ b/packages/protocol-ts/test/golden.test.mjs
@@ -25,12 +25,13 @@ test('single limit/grid/capability generation is pinned', () => {
   assert.match(fingerprints.limits, /^[0-9a-f]{16}$/);
   assert.ok(generated.includes(`LIMITS_FINGERPRINT = "${fingerprints.limits}"`));
   const gridIds = [...generated.matchAll(/\{\s*id:\s*"([^"]+)",\s*displayName:\s*"([^"]+)",\s*powerUser:\s*(true|false)\s*\}/g)];
-  assert.equal(gridIds.length, 18);
+  assert.equal(gridIds.length, 19);
   const ids = gridIds.map((m) => m[1]);
   assert.deepEqual(ids, [
     'custom',
     'google_arts_and_culture',
     'zoomify',
+    'gigapan',
     'iiif',
     'deepzoom',
     'generic',


### PR DESCRIPTION
## Summary

- add pure Gigapan discovery for viewer pages and `.kml` metadata
- build the full-resolution 256px tile grid using Gigapan's `/get_ge_tile` endpoint
- register Gigapan across the core, CLI, protocol artifacts, and documentation

Closes https://github.com/lovasoa/dezoomify-rs/issues/356

## Verification

- `cargo test -p dezoomify-core`
- `cargo xtask test core --parity`
- `cargo test -p dezoomify-protocol`
- `cargo xtask test protocol`
- `cargo test -p dezoomify-cli`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo xtask protocol generate --check`
- `cargo xtask fixtures verify`

The repository-wide check is otherwise clean; `cargo xtask check` is blocked only because `cargo-deny 0.20.2` is not installed in the environment. The full workspace test also reaches unrelated JavaScript suites that require missing `esbuild` and `vite` dependencies.
