### PR TITLE
ci: fix master validation gates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+
+cargo xtask ci check
+cargo xtask test ui

--- a/crates/xtask/src/browser.rs
+++ b/crates/xtask/src/browser.rs
@@ -86,6 +86,7 @@ pub fn test_ui(args: &[String]) -> Result<(), String> {
     super::reject_unknown_args("test ui", args)?;
     // Documented ui gate (docs/testing.md): controller, view rendering,
     // accessibility, i18n, and mobile suites.
+    generate_web_artifacts()?;
     for suite in [
         "test/controller.test.mjs",
         "test/view-rendering.test.mjs",

--- a/crates/xtask/src/release/sign.rs
+++ b/crates/xtask/src/release/sign.rs
@@ -56,9 +56,7 @@ fn release_sign(plan: &Plan, artifacts: &Path) -> Result<(), String> {
         if let Ok(pass) = std::env::var(GPG_PASSPHRASE_ENV) {
             cmd.args(["--pinentry-mode", "loopback", "--passphrase", &pass]);
         }
-        cmd.args(["--detach-sign", "--output"])
-            .arg(&sig)
-            .arg(&file);
+        cmd.args(["--detach-sign", "--output"]).arg(&sig).arg(&file);
         let status = cmd
             .status()
             .map_err(|e| format!("failed to run gpg: {e}"))?;

--- a/crates/xtask/src/setup.rs
+++ b/crates/xtask/src/setup.rs
@@ -5,6 +5,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
     if !args.is_empty() {
         return Err("usage: cargo xtask setup (no options)".to_string());
     }
+    configure_git_hooks()?;
     let mut failures: Vec<String> = Vec::new();
 
     let rustc = version_of("rustc", &["--version"])?;
@@ -34,6 +35,22 @@ pub fn run(args: &[String]) -> Result<(), String> {
         Ok(())
     } else {
         Err(failures.join("\n"))
+    }
+}
+
+/// Point this checkout at the versioned pre-commit checks.
+fn configure_git_hooks() -> Result<(), String> {
+    let root = super::repo_root();
+    let status = std::process::Command::new("git")
+        .args(["config", "--local", "core.hooksPath", ".githooks"])
+        .current_dir(&root)
+        .status()
+        .map_err(|e| format!("failed to configure versioned Git hooks: {e}"))?;
+    if status.success() {
+        println!("git hooks: .githooks");
+        Ok(())
+    } else {
+        Err("failed to configure versioned Git hooks".to_string())
     }
 }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,6 +45,11 @@ the full deterministic suite. Focused targets are documented in
 [Testing](testing.md). No test other than `test live` contacts public source
 sites.
 
+`cargo xtask setup` configures this checkout to use the versioned
+`.githooks/pre-commit` hook. The hook runs `cargo xtask ci check` and
+`cargo xtask test ui`, which catch formatting and generated shared-UI artifact
+failures before a commit.
+
 ## Builds
 
 `cargo xtask build <target>` output:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -91,7 +91,9 @@ dictionary coverage with per-key English fallback; the extension renders
 through its vendored dictionary mirror with
 no local replica), and `test/ui-mobile.test.mjs` (560/380px parity over the
 canonical theme the extension page links, and static 360px CSS reachability invariants). It is
-tracked and always present.
+tracked and always present. The UI target regenerates the ignored browser
+mirrors before these suites so their source and vendor parity checks always
+have their required artifacts.
 
 `e2e-artifacts/` (repository root) is not a suite and never runs in any
 `cargo xtask test` or `cargo xtask ci` lane. It holds only untracked


### PR DESCRIPTION
## Summary
- apply the Rust formatter output that currently fails the check lane
- generate browser mirrors before the UI suite reads them
- configure a versioned pre-commit hook for the check and UI gates

## Validation
- cargo xtask ci local
- cargo xtask test all