### PR TITLE
Avoid repeated CORS tile fetches in the web app

### DIFF
--- a/crates/fixture-server/tests/webapp-e2e/webapp.spec.js
+++ b/crates/fixture-server/tests/webapp-e2e/webapp.spec.js
@@ -233,11 +233,18 @@ test("webapp displays CORS-blocked ordinary tiles instead of failing", async ({ 
   // fetches are same-origin /fetch URLs here; matching on the tile path
   // (not the host) aborts exactly the readable tile fetches while plain
   // <img> loads for the same URLs succeed.
+  let readableRequests = 0;
+  let imageRequests = 0;
   await page.route(
     (url) => url.href.includes("pyramid_files"),
     async (route) => {
-      if (route.request().resourceType() === "image") await route.continue();
-      else await route.abort();
+      if (route.request().resourceType() === "image") {
+        imageRequests += 1;
+        await route.continue();
+      } else {
+        readableRequests += 1;
+        await route.abort();
+      }
     },
   );
   await page.goto(ADDR + "/beta/", { waitUntil: "networkidle" });
@@ -255,4 +262,6 @@ test("webapp displays CORS-blocked ordinary tiles instead of failing", async ({ 
   const size = await canvas.evaluate((el) => ({ width: el.width, height: el.height }));
   assert.equal(size.width, 512, "displayed image width");
   assert.equal(size.height, 512, "displayed image height");
+  assert.equal(readableRequests, 1, "one tile classifies the CORS policy for the origin");
+  assert.ok(imageRequests > 1, "later tiles load directly as ordinary images");
 });

--- a/docs/browser-runtime.md
+++ b/docs/browser-runtime.md
@@ -66,14 +66,14 @@ The website uses this order:
 
 1. Direct browser fetch with cookies, `Authorization`, and browser credentials omitted.
 2. After a classified CORS or network failure, or a direct fetch that does not complete within the 1500 ms metadata window, automatic metadata CORS proxy fallback when the metadata request is public and non-credential.
-3. For unprocessed ordinary tiles, an `<img>` element when display is possible without readable bytes.
+3. For unprocessed ordinary tiles, one direct readable attempt classifies each origin. A successful ordinary `<img>` fallback marks that origin display-only for the job, so later ordinary tiles load directly through `<img>`.
 4. A typed recovery action offering the [extension](extension.md) or [native app](native-apps.md) when no accepted browser route can supply readable bytes.
 
 The website always shows the active transport as direct browser fetch or the metadata CORS proxy, including an automatic transition after the classified direct failure. Proxy fallback requires no per-attempt consent.
 
 The extension transport is tab-origin direct fetch followed by `<img>` tainted display-only. The extension fetches readable bytes in the monitored tab's origin context under activeTab or granted host permissions; the active transport stays visible in the modal. When readable bytes are unavailable (CORS-blocked without a grant), tiles render as ordinary `<img>` elements: visible but tainted, with no JavaScript pixel reads, hashing, processing, `toBlob`, or `toDataURL`. The extension never uses the metadata CORS proxy.
 
-The proxy is not a general relay and serves metadata only, never tiles. Both the browser-to-proxy request and the proxy's upstream request omit cookies, `Authorization`, and browser credentials. The proxy accepts only validated metadata requests for eligible public resources, blocks private and local networks, follows bounded redirects, limits size and duration, strips headers outside its allowlist, and returns explicit CORS headers. The frontend additionally holds every proxy request (metadata and any tile images fetched through the proxy) to a single global budget of at most 4 requests in flight and at most 4 request starts per second; direct tile requests never draw from that budget and keep their own per-host pacing. Details are in [Security](security.md).
+The proxy is not a general relay and serves metadata only, never tiles. Both the browser-to-proxy request and the proxy's upstream request omit cookies, `Authorization`, and browser credentials. The proxy accepts only validated metadata requests for eligible public resources, blocks private and local networks, follows bounded redirects, limits size and duration, strips headers outside its allowlist, and returns explicit CORS headers. The frontend holds metadata-proxy requests to a single global budget of at most 4 requests in flight and at most 4 request starts per second; direct tile requests never draw from that budget and keep their own per-host pacing. Details are in [Security](security.md).
 
 ## Limits and capabilities
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,16 @@ let activeTransport: string | null = null;
 let client: DiscoveryClient | null = null;
 let jobToken = 0;
 let resultBlobUrl: string | null = null;
+type TileTransport = "readable" | "ordinary-image";
+
+interface TileOriginState {
+  mode?: TileTransport;
+  ready?: Promise<TileTransport>;
+}
+
+// A CORS policy is stable for a job, so one tile classifies each origin while
+// concurrent tiles wait instead of all repeating the same failed fetch.
+let tileOrigins = new Map<string, TileOriginState>();
 // Pause v1 (todo 5.7, suspend-acquisition): the website stops scheduling new
 // tiles while paused, finishes in-flight work, retains the canvas, and
 // re-drives on resume. Integration-layer only; the engine pause lives in
@@ -1102,7 +1112,11 @@ async function fetchMetadataFor(
   return { bytes, finalUri, via };
 }
 
-async function fetchTileFor(url: string, headers: Record<string, string>): Promise<{ bytes: ArrayBuffer }> {
+async function fetchTileFor(
+  url: string,
+  headers: Record<string, string>,
+  maxRetries: number = TILE_MAX_RETRIES,
+): Promise<{ bytes: ArrayBuffer }> {
   let lastOutcome = "network-error";
   let lastStatus: number | undefined;
   for (let attempt = 0; ; attempt++) {
@@ -1113,7 +1127,7 @@ async function fetchTileFor(url: string, headers: Record<string, string>): Promi
     }
     lastOutcome = direct.outcome;
     lastStatus = direct.status;
-    if (direct.outcome === "cancelled" || attempt >= TILE_MAX_RETRIES) {
+    if (direct.outcome === "cancelled" || attempt >= maxRetries) {
       break;
     }
     await sleep(tileRetryDelayMs(attempt));
@@ -1123,7 +1137,7 @@ async function fetchTileFor(url: string, headers: Record<string, string>): Promi
     "Part of the image could not be saved. Try again in a moment.",
     true,
     undefined,
-    `tile fetch: ${lastOutcome} (HTTP ${lastStatus ?? "n/a"}) from ${shortUrl(url)} after ${TILE_MAX_RETRIES + 1} attempts`,
+    `tile fetch: ${lastOutcome} (HTTP ${lastStatus ?? "n/a"}) from ${shortUrl(url)} after ${maxRetries + 1} attempts`,
   );
 }
 
@@ -1187,6 +1201,16 @@ function loadTileImage(url: string, ms: number = REQUEST_TIMEOUT_MS): Promise<HT
     img.referrerPolicy = "no-referrer";
     img.src = url;
   });
+}
+
+function tileOrigin(url: string): string {
+  try {
+    return new URL(url, typeof window === "undefined" ? undefined : window.location.href).origin;
+  } catch {
+    // Invalid tile URLs fail later through the normal typed fetch path; keep
+    // their classification isolated rather than accidentally sharing one.
+    return url;
+  }
 }
 
 function setCanvasVisible(visible: boolean): void {
@@ -1330,10 +1354,11 @@ function enqueueProcess(client2: DiscoveryClient, recipe: string, bytes: ArrayBu
  * ordinary image display (canvas now tainted, display-only); false when it
  * arrived as readable bytes (canvas stays clean).
  *
- * Readable bytes come first so CORS-granting sites keep the clean save.
- * After the readable retries are exhausted, an unprocessed tile falls back
- * to a plain <img> (no CORS needed): the user sees the picture and can
- * right-click it, but scripts can no longer read or save the canvas.
+ * Readable bytes come first so CORS-granting sites keep the clean save. One
+ * ordinary tile classifies its origin: a single unreadable fetch followed by
+ * a successful plain <img> sends later ordinary tiles straight to <img>.
+ * The user sees the picture and can right-click it, but scripts can no longer
+ * read or save the canvas.
  * Processed tiles rethrow: decrypt/re-encode needs readable bytes.
  * When the <img> also fails, the original readable failure (with its
  * technical chain) is what the job reports.
@@ -1360,6 +1385,57 @@ async function drawTile(
       ctx2d.drawImage(source, 0, 0, fullW, fullH, tile.x, tile.y, planW, planH);
     }
   };
+  const drawOrdinaryImage = async (): Promise<void> => {
+    await throttleTileStart(tile.uri);
+    const img = await loadTileImage(tile.uri);
+    await drawBitmap(img);
+  };
+  if (isOrdinaryImageTile(tile.processing)) {
+    const origin = tileOrigin(tile.uri);
+    let state = tileOrigins.get(origin);
+    if (state?.ready) {
+      await state.ready;
+    } else if (!state) {
+      let resolveTransport!: (mode: TileTransport) => void;
+      let rejectTransport!: (reason?: unknown) => void;
+      const ready = new Promise<TileTransport>((resolve, reject) => {
+        resolveTransport = resolve;
+        rejectTransport = reject;
+      });
+      // The worker that owns classification reports failures through drawTile;
+      // this handler prevents a second unhandled rejection before waiters run.
+      void ready.catch(() => undefined);
+      state = { ready };
+      tileOrigins.set(origin, state);
+      try {
+        const { bytes } = await fetchTileFor(tile.uri, tile.headers ?? {}, 0);
+        const bitmap = await decodeTileBitmap(bytes);
+        try {
+          await drawBitmap(bitmap);
+        } finally {
+          bitmap.close();
+        }
+        state.mode = "readable";
+        resolveTransport("readable");
+        return false;
+      } catch (readableFailure) {
+        try {
+          await drawOrdinaryImage();
+          state.mode = "ordinary-image";
+          resolveTransport("ordinary-image");
+          return true;
+        } catch {
+          tileOrigins.delete(origin);
+          rejectTransport(readableFailure);
+          throw readableFailure;
+        }
+      }
+    }
+    if (state.mode === "ordinary-image") {
+      await drawOrdinaryImage();
+      return true;
+    }
+  }
   let readableFailure: unknown = null;
   try {
     let { bytes } = await fetchTileFor(tile.uri, tile.headers ?? {});
@@ -1376,19 +1452,12 @@ async function drawTile(
   } catch (error) {
     readableFailure = error;
   }
-  if (!isOrdinaryImageTile(tile.processing)) throw readableFailure;
-  try {
-    await throttleTileStart(tile.uri);
-    const img = await loadTileImage(tile.uri);
-    await drawBitmap(img);
-    return true;
-  } catch {
-    throw readableFailure;
-  }
+  throw readableFailure;
 }
 
 async function runJob(url: string): Promise<void> {
   const token = ++jobToken;
+  tileOrigins = new Map();
   resetActivity(url);
   setCanvasVisible(false);
   jobPaused = false;


### PR DESCRIPTION
Summary:\n- Classify each ordinary tile origin once per job.\n- Load later CORS-blocked tiles directly through ordinary images.\n- Cover the request reduction in Chromium E2E.\n\nValidation:\n- pnpm exec tsc --noEmit\n- cargo xtask test web --e2e\n- cargo xtask check is blocked by a pre-existing rustfmt failure in crates/xtask/src/release/sign.rs.