### PR TITLE
chore(deps): consolidate dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,25 +808,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -825,12 +833,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2413,17 +2421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3228,6 +3225,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5541,18 +5548,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -5579,6 +5599,12 @@ dependencies = [
  "unic-ucd-ident",
  "url",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5854,15 +5880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ aes = "0.9"
 cbc = "0.2"
 thiserror = "2"
 html-escape = "0.2"
-ureq = "2.12"
+ureq = "3.4"
 rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
 sha2 = "0.10"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }

--- a/crates/dezoomify-native/Cargo.toml
+++ b/crates/dezoomify-native/Cargo.toml
@@ -23,7 +23,7 @@ tiff = "0.11"
 tokio.workspace = true
 dezoomify-fixture-server = { path = "../fixture-server" }
 axum.workspace = true
-criterion = "0.5"
+criterion = "0.8"
 
 [[bench]]
 name = "native_pipeline"

--- a/crates/dezoomify-native/benches/native_pipeline.rs
+++ b/crates/dezoomify-native/benches/native_pipeline.rs
@@ -8,12 +8,13 @@
 //! helpers the driver uses (`estimated_peak_*`, `should_spill`,
 //! `required_memory_bytes`), so the bench tracks the shipped decision.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use dezoomify_native::pipeline::{
     encode_jpeg, encode_png, encode_tiff, estimated_peak_legacy_bytes,
     estimated_peak_streaming_bytes, required_memory_bytes, should_spill, MAX_CONCURRENT,
 };
 use dezoomify_native::pool::run_bounded;
+use std::hint::black_box;
 
 fn sweep_image(width: u32, height: u32) -> image::RgbaImage {
     let mut image = image::RgbaImage::new(width, height);

--- a/crates/dezoomify-native/src/http.rs
+++ b/crates/dezoomify-native/src/http.rs
@@ -138,20 +138,25 @@ pub fn fetch(
     }
     let deadline = Instant::now() + limits.timeout;
     let mut redirects: usize = 0;
-    let mut builder = ureq::AgentBuilder::new()
-        .redirects(0)
-        .timeout_connect(limits.connect_timeout)
+    let mut builder = ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .max_redirects(0)
+        .timeout_connect(Some(limits.connect_timeout))
         .max_idle_connections_per_host(limits.max_idle_per_host.max(1));
     if limits.tls.accept_invalid_certs {
-        builder = builder.tls_config(std::sync::Arc::new(insecure_client_config()?));
+        builder = builder.tls_config(
+            ureq::tls::TlsConfig::builder()
+                .disable_verification(true)
+                .build(),
+        );
     }
-    let agent = builder.build();
+    let agent = builder.build().into();
     loop {
         let response = fetch_once(&agent, &request, limits, &deadline)?;
-        let is_redirect =
-            REDIRECT_CODES.contains(&response.status()) && response.header("location").is_some();
+        let is_redirect = REDIRECT_CODES.contains(&response.status().as_u16())
+            && response.headers().get("location").is_some();
         if !is_redirect {
-            let status = response.status();
+            let status = response.status().as_u16();
             let final_uri = request.uri.clone();
             let body = read_body(response, limits)?;
             return Ok(FetchOutcome {
@@ -168,7 +173,9 @@ pub fn fetch(
         }
         redirects += 1;
         let location = response
-            .header("location")
+            .headers()
+            .get("location")
+            .and_then(|value| value.to_str().ok())
             .ok_or_else(|| NativeError::new("transport.bad-redirect", "missing location"))?;
         let next = resolve_redirect(&request.uri, location)?;
         request = rebuild_for_redirect(&request, &next, auth)?;
@@ -233,7 +240,7 @@ fn fetch_once(
     request: &EffectiveRequest,
     limits: &FetchLimits,
     deadline: &Instant,
-) -> Result<ureq::Response, NativeError> {
+) -> Result<ureq::http::Response<ureq::Body>, NativeError> {
     let mut attempts = limits.retries.saturating_add(1);
     loop {
         attempts -= 1;
@@ -246,29 +253,39 @@ fn fetch_once(
         }
         let mut call = agent.get(&request.uri);
         for (name, value) in &request.headers {
-            call = call.set(name, value);
+            call = call.header(name.as_str(), value.as_str());
         }
-        let result = call.timeout(remaining).call();
+        let result = call.config().timeout_global(Some(remaining)).build().call();
         match result {
             Ok(response) => return Ok(response),
-            Err(ureq::Error::Status(_status, response)) => return Ok(response),
-            Err(ureq::Error::Transport(transport)) => {
+            Err(ureq::Error::Timeout(_)) => {
+                if attempts > 0 {
+                    continue;
+                }
+                return Err(NativeError::new(
+                    "transport.timeout",
+                    "fetch request timed out",
+                ));
+            }
+            Err(error) => {
                 if attempts > 0 {
                     continue;
                 }
                 return Err(NativeError::new(
                     "transport.network-error",
-                    format!("network failure: {}", transport),
+                    format!("network failure: {error}"),
                 ));
             }
         }
     }
 }
 
-fn read_body(response: ureq::Response, limits: &FetchLimits) -> Result<Vec<u8>, NativeError> {
-    let mut reader = response
-        .into_reader()
-        .take(limits.max_bytes.saturating_add(1));
+fn read_body(
+    response: ureq::http::Response<ureq::Body>,
+    limits: &FetchLimits,
+) -> Result<Vec<u8>, NativeError> {
+    let body = response.into_parts().1;
+    let mut reader = body.into_reader().take(limits.max_bytes.saturating_add(1));
     let mut body = Vec::new();
     reader.read_to_end(&mut body).map_err(|e| {
         NativeError::new("transport.network-error", format!("body read failed: {e}"))
@@ -280,63 +297,6 @@ fn read_body(response: ureq::Response, limits: &FetchLimits) -> Result<Vec<u8>, 
         ));
     }
     Ok(body)
-}
-
-fn insecure_client_config() -> Result<rustls::ClientConfig, NativeError> {
-    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-    use rustls::crypto::ring as provider;
-    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-    use std::sync::Arc as StdArc;
-
-    #[derive(Debug)]
-    struct AcceptAll;
-    impl ServerCertVerifier for AcceptAll {
-        fn verify_server_cert(
-            &self,
-            _end_entity: &CertificateDer<'_>,
-            _intermediates: &[CertificateDer<'_>],
-            _server_name: &ServerName<'_>,
-            _ocsp_response: &[u8],
-            _now: UnixTime,
-        ) -> Result<ServerCertVerified, rustls::Error> {
-            Ok(ServerCertVerified::assertion())
-        }
-        fn verify_tls12_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _algorithm: &rustls::DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-        fn verify_tls13_signature(
-            &self,
-            _message: &[u8],
-            _cert: &CertificateDer<'_>,
-            _algorithm: &rustls::DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-            vec![
-                rustls::SignatureScheme::RSA_PKCS1_SHA256,
-                rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
-                rustls::SignatureScheme::ED25519,
-                rustls::SignatureScheme::RSA_PSS_SHA256,
-            ]
-        }
-    }
-
-    let builder =
-        rustls::ClientConfig::builder_with_provider(StdArc::new(provider::default_provider()))
-            .with_safe_default_protocol_versions()
-            .map_err(|e| NativeError::new("transport.tls", format!("tls setup failed: {e}")))?;
-    let mut config = builder
-        .dangerous()
-        .with_custom_certificate_verifier(StdArc::new(AcceptAll))
-        .with_no_client_auth();
-    config.alpn_protocols = vec![b"http/1.1".to_vec()];
-    Ok(config)
 }
 
 fn resolve_redirect(base: &str, location: &str) -> Result<String, NativeError> {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "markdown-it": "15.0.1"
   },
   "devDependencies": {
-    "@types/node": "24.3.1",
+    "@types/node": "26.4.1",
     "esbuild": "0.28.2",
     "typescript": "7.0.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 15.0.1
     devDependencies:
       '@types/node':
-        specifier: 24.3.1
-        version: 24.3.1
+        specifier: 26.4.1
+        version: 26.4.1
       esbuild:
         specifier: 0.28.2
         version: 0.28.2
@@ -45,7 +45,7 @@ importers:
         version: 7.0.2
       vite:
         specifier: ^8.0.0
-        version: 8.2.2(@types/node@24.3.1)(esbuild@0.28.2)
+        version: 8.2.2(@types/node@26.4.1)(esbuild@0.28.2)
 
   apps/extension:
     devDependencies:
@@ -321,8 +321,8 @@ packages:
   '@tauri-apps/plugin-opener@2.5.5':
     resolution: {integrity: sha512-xvzGai5aQds8j8R8RsUK/lW6pGG50YgOYIPLzvkqmkwAj7dfySOD7sGtejRzvVdMmv1EQfKVEFh1MvmDp8QR0g==}
 
-  '@types/node@24.3.1':
-    resolution: {integrity: sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==}
+  '@types/node@26.4.1':
+    resolution: {integrity: sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -669,8 +669,8 @@ packages:
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
-  undici-types@7.10.0:
-    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   vite@8.2.2:
     resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
@@ -850,9 +850,9 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
-  '@types/node@24.3.1':
+  '@types/node@26.4.1':
     dependencies:
-      undici-types: 7.10.0
+      undici-types: 8.3.0
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -1164,9 +1164,9 @@ snapshots:
 
   uhyphen@0.2.0: {}
 
-  undici-types@7.10.0: {}
+  undici-types@8.3.0: {}
 
-  vite@8.2.2(@types/node@24.3.1)(esbuild@0.28.2):
+  vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.7
@@ -1174,6 +1174,6 @@ snapshots:
       rolldown: 1.2.7
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 24.3.1
+      '@types/node': 26.4.1
       esbuild: 0.28.2
       fsevents: 2.3.3


### PR DESCRIPTION
Consolidates the remaining dependency update PRs #1011, #1010, and #1004 into one change.

Updates:
- criterion 0.5 -> 0.8
- @types/node 24.3.1 -> 26.4.1
- ureq 2.12 -> 3.4

Includes the required ureq 3 API migration and benchmark deprecation cleanup.