### PR TITLE
Add extension permission consent flow

### DIFF
--- a/apps/extension/src/job/controller.ts
+++ b/apps/extension/src/job/controller.ts
@@ -68,6 +68,8 @@ export function createJobController(deps: JobControllerDeps) {
   let disposed = false;
   /** @type {Set<string>} */
   const settled = new Set();
+  /** Requests paused while the visible job tab asks for an optional host grant. */
+  const waitingForPermission = new Map<string, { effect: EngineEnvelope; failure: { blocked_reason?: string; [key: string]: unknown } }>();
   let chain = Promise.resolve();
 
   function sendToEngine(message: unknown) { deps.worker.postMessage(message); }
@@ -98,7 +100,11 @@ export function createJobController(deps: JobControllerDeps) {
       const failure = deps.classifyFailure(error);
       if (failure.blocked_reason === "access-required") {
         const hosts = error && typeof error === "object" && "hosts" in error && Array.isArray(error.hosts) ? error.hosts.filter((host): host is string => typeof host === "string") : [];
+        // A visible, explicit user action may grant this host. Keep the
+        // effect pending so the same acquisition can resume after a grant.
+        waitingForPermission.set(request.id, { effect, failure });
         deps.onPermissionRequired({ hosts, requestId: request.id, jobId: effect.job });
+        return;
       }
       if (!cancelled) sendToEngine({ type: "engine.failure", jobId: effect.job, requestId: request.id, error: failure });
     }
@@ -178,6 +184,19 @@ export function createJobController(deps: JobControllerDeps) {
     selectImage(image: string) { sendToEngine({ type: "engine.command", command: { type: "select-image", job: deps.binding().jobId, image } }); },
     selectLevel(level: string) { sendToEngine({ type: "engine.command", command: { type: "select-level", job: deps.binding().jobId, level } }); },
     choosePartial(recovery: string, keepPartial: boolean) { sendToEngine({ type: "engine.command", command: { type: "partial-choice", job: deps.binding().jobId, recovery, keep_partial: keepPartial } }); },
+    resolvePermission(granted: boolean) {
+      const pending = [...waitingForPermission.entries()];
+      waitingForPermission.clear();
+      for (const [id, { effect, failure }] of pending) {
+        if (cancelled) return;
+        if (!granted) {
+          sendToEngine({ type: "engine.failure", jobId: effect.job, requestId: id, error: failure });
+          continue;
+        }
+        settled.delete(id);
+        void acquire(effect);
+      }
+    },
     cancel() {
       if (cancelled) return;
       cancelled = true;

--- a/apps/extension/src/job/index.ts
+++ b/apps/extension/src/job/index.ts
@@ -34,6 +34,10 @@ let started = false;
 let selected = false;
 let hostFailed = false;
 let lastSource = "";
+// The engine emits the initial 0/N tile snapshot before it dispatches tile
+// effects. Keep it while a permission view temporarily replaces the job view
+// so approval resumes the same determinate progress display immediately.
+let lastTileProgress: { current: number; total: number } | null = null;
 const bootstrapJobId = new URLSearchParams(location.hash.slice(1)).get("jobId");
 
 function requestId(prefix: string) { return `${prefix}-${crypto.randomUUID?.() ?? Date.now().toString(36)}`; }
@@ -44,6 +48,7 @@ function root() { return document.getElementById("dz-job-app"); }
 function render(status: string, ctx: ViewContext = {}) {
   const target = root();
   if (!target) return;
+  target.className = "";
   seq += 1;
   renderView(target, { status, seq, sessionId: binding?.jobId ?? "job:pending", transport: "browser-session", imageCount: 0, ...(ctx.failure ? { error: ctx.failure } : {}) }, {
     onSubmitUrl: () => {},
@@ -67,23 +72,59 @@ function closeJob() {
 
 function showAccessRequired(detail: { hosts: string[] }) {
   const hosts = Array.isArray(detail.hosts) ? detail.hosts : [];
-  render("failed", {
-    failure: { code: "access-required", category: "extension", retryable: true, message: `This image uses files from: ${hosts.join(", ") || "another site"}` },
-    jobActivity: { startedAt: Date.now(), stepLabel: "Waiting for access" },
-  });
   const target = root();
-  if (!target || target.querySelector("[data-dz-allow-access]")) return;
+  if (!target) return;
+  const origin = hosts.length === 1 ? hosts[0] : "the required image host";
+  target.replaceChildren();
+  target.className = "dz-permission-request";
+  const icon = document.createElement("div");
+  icon.className = "dz-permission-icon";
+  icon.setAttribute("aria-hidden", "true");
+  const lock = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  lock.setAttribute("viewBox", "0 0 24 24");
+  lock.setAttribute("fill", "none");
+  lock.setAttribute("stroke", "currentColor");
+  lock.setAttribute("stroke-width", "1.8");
+  const shackle = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  shackle.setAttribute("d", "M8 10V7a4 4 0 0 1 8 0v3");
+  const body = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+  body.setAttribute("x", "5"); body.setAttribute("y", "10"); body.setAttribute("width", "14"); body.setAttribute("height", "10"); body.setAttribute("rx", "1");
+  lock.append(shackle, body);
+  icon.append(lock);
+  const title = document.createElement("h1");
+  title.textContent = "Allow access to continue";
+  const explanation = document.createElement("p");
+  explanation.textContent = `This image uses files from ${origin}.`;
+  const reason = document.createElement("p");
+  reason.textContent = "Dezoomify needs access to read those files and assemble your image in this browser.";
   const button = document.createElement("button");
   button.type = "button";
-  button.className = "dz-btn-tactile";
+  button.className = "dz-btn-tactile dz-permission-button";
   button.dataset.dzAllowAccess = "true";
   button.textContent = "Allow access and continue";
   button.addEventListener("click", () => {
     // This click is the only path that may cause the coordinator to call the
     // browser permission API. The worker/fetch transport never does so.
-    void send(boundEnvelope("dz.job.permission-required", { origins: hosts })).catch(() => {});
+    button.disabled = true;
+    button.textContent = "Requesting access…";
+    void send(boundEnvelope("dz.job.permission-required", { origins: hosts })).catch(() => {
+      button.disabled = false;
+      button.textContent = "Allow access and continue";
+    });
   });
-  target.append(button);
+  target.append(icon, title, explanation, reason, button);
+}
+
+function resolvePermission(message: Record<string, unknown>) {
+  if (!binding || message.jobId !== binding.jobId || typeof message.granted !== "boolean") return;
+  if (message.granted) {
+    const progress = lastTileProgress;
+    render("downloading", {
+      ...(progress ? { currentProgress: progress } : {}),
+      jobActivity: { startedAt: Date.now(), stepLabel: "Acquiring image tiles" },
+    });
+  }
+  controller?.resolvePermission(message.granted);
 }
 
 /**
@@ -168,7 +209,11 @@ function createAssembly(sourceUrl: string) {
 
 function handleEvent(event: JobEvent) {
   if (hostFailed) return;
-  if (event.type === "progress") render("downloading", { currentProgress: { current: event.acquired, total: event.total }, jobActivity: { startedAt: Date.now(), stepLabel: "Acquiring image tiles" } });
+  if (event.type === "progress") {
+    if (typeof event.acquired !== "number" || typeof event.total !== "number") return;
+    lastTileProgress = { current: event.acquired, total: event.total };
+    render("downloading", { currentProgress: lastTileProgress, jobActivity: { startedAt: Date.now(), stepLabel: "Acquiring image tiles" } });
+  }
   else if (event.type === "failed") render("failed", { failure: event.error, jobActivity: { startedAt: Date.now(), stepLabel: "Job failed" } });
   else if (event.type === "cancelled") render("cancelled", { jobActivity: { startedAt: Date.now(), stepLabel: "Cancelled" } });
   else if (event.type === "completed" || event.type === "partial-completed") render("completed", { jobActivity: { startedAt: Date.now(), stepLabel: event.type === "completed" ? "Completed" : "Completed (partial)" } });
@@ -197,6 +242,7 @@ function setup(bound: unknown) {
     frameId: bound.frameId,
     documentGeneration: bound.documentGeneration,
   };
+  lastTileProgress = null;
   const activeBinding = binding;
   const worker = new Worker(new URL("./worker.js", import.meta.url), { type: "module" });
   jobWorker = worker;
@@ -260,6 +306,7 @@ api?.runtime?.onMessage?.addListener((message) => {
   if (message?.type === "dz.job.binding") setup(message);
   else if (message?.type === "dz.job.candidates") candidates(message);
   else if (message?.type === "dz.job.fetch") sourceTransport?.handleMessage?.(message);
+  else if (message?.type === "dz.job.permission-required") resolvePermission(message);
 });
 
 window.addEventListener("beforeunload", () => {

--- a/apps/extension/src/vendor/theme.css
+++ b/apps/extension/src/vendor/theme.css
@@ -287,6 +287,55 @@ abbr[title] {
   color: var(--dz-text-primary);
 }
 
+/* Dedicated extension-job consent view. Permission is an intentional pause,
+ * not an error, so it gets one quiet surface and one clear action. */
+.dz-permission-request {
+  width: min(100%, 38rem);
+  margin: auto;
+  padding: clamp(2.5rem, 7vw, 5rem) clamp(1.5rem, 6vw, 4.5rem);
+  text-align: center;
+}
+
+.dz-permission-icon {
+  display: grid;
+  place-items: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  margin: 0 auto 1.5rem;
+  border: 1px solid var(--dz-surface-border);
+  border-radius: var(--dz-radius);
+  color: var(--dz-link-color);
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.dz-permission-icon svg {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+
+.dz-permission-request h1 {
+  margin: 0 0 1rem;
+  color: var(--dz-text-primary);
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  letter-spacing: -0.035em;
+  line-height: 1.15;
+}
+
+.dz-permission-request p {
+  margin: 0 auto 0.65rem;
+  color: var(--dz-text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.dz-permission-button {
+  width: min(100%, 24rem);
+  min-height: 3.75rem;
+  margin-top: 1.75rem;
+}
+
 /* Title & Description */
 .dz-header {
   margin-bottom: 2.25rem;

--- a/apps/extension/tests/unit/job-controller.test.mjs
+++ b/apps/extension/tests/unit/job-controller.test.mjs
@@ -84,6 +84,39 @@ test("a tile that cannot decode reports a failed acquisition, not a broken outpu
   assert.equal(sent.some((message) => message.type === "engine.bytes"), false);
 });
 
+test("an access grant re-drives the paused acquisition instead of failing the job", async () => {
+  let attempts = 0;
+  const sent = [];
+  // Replace the injected transport behavior through a fresh focused harness,
+  // keeping the permission callback observable just like the job page does.
+  const retried = [];
+  const resumed = createJobController({
+    worker: { postMessage: (message) => sent.push(message) },
+    binding: () => BINDING,
+    sourceTransport: { async fetchResource() { throw new Error("not used"); } },
+    extensionTransport: {
+      async fetchResource() {
+        attempts += 1;
+        if (attempts === 1) throw Object.assign(new Error("grant required"), { category: "access-required", hosts: ["https://cdn.test"] });
+        return { bytes: new Uint8Array([1]) };
+      },
+      cancel() {},
+    },
+    assembly: fakeAssembly(),
+    classifyFailure: (error) => ({ blocked_reason: error?.category ?? "network", code: "extension.network", retryable: true }),
+    onPermissionRequired: (detail) => retried.push(detail),
+    onPartialDecision() {}, onHostFailure() {}, onEvent() {}, onUnsupportedEffect() {},
+  });
+  resumed.handleEngineMessages([TILE_EFFECT]);
+  await flush();
+  assert.equal(sent.some((message) => message.type === "engine.failure"), false, "grantable access waits for the decision");
+  assert.equal(retried.length, 1);
+  resumed.resolvePermission(true);
+  await flush();
+  assert.equal(attempts, 2);
+  assert.ok(sent.some((message) => message.type === "engine.bytes"));
+});
+
 test("metadata requests route through the source transport", async () => {
   const { controller, seen } = harness();
   controller.handleEngineMessages([{

--- a/packages/shared-ui/src/styles/theme.css
+++ b/packages/shared-ui/src/styles/theme.css
@@ -287,6 +287,55 @@ abbr[title] {
   color: var(--dz-text-primary);
 }
 
+/* Dedicated extension-job consent view. Permission is an intentional pause,
+ * not an error, so it gets one quiet surface and one clear action. */
+.dz-permission-request {
+  width: min(100%, 38rem);
+  margin: auto;
+  padding: clamp(2.5rem, 7vw, 5rem) clamp(1.5rem, 6vw, 4.5rem);
+  text-align: center;
+}
+
+.dz-permission-icon {
+  display: grid;
+  place-items: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  margin: 0 auto 1.5rem;
+  border: 1px solid var(--dz-surface-border);
+  border-radius: var(--dz-radius);
+  color: var(--dz-link-color);
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.dz-permission-icon svg {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+
+.dz-permission-request h1 {
+  margin: 0 0 1rem;
+  color: var(--dz-text-primary);
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  letter-spacing: -0.035em;
+  line-height: 1.15;
+}
+
+.dz-permission-request p {
+  margin: 0 auto 0.65rem;
+  color: var(--dz-text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.dz-permission-button {
+  width: min(100%, 24rem);
+  min-height: 3.75rem;
+  margin-top: 1.75rem;
+}
+
 /* Title & Description */
 .dz-header {
   margin-bottom: 2.25rem;


### PR DESCRIPTION
## Summary
- add an explicit extension job consent view for optional host access
- pause and resume blocked tile acquisition after the user grants access
- preserve tile progress across the permission view and add regression coverage

## Validation
- `cargo xtask test extension` — 119 unit/integration tests passed
- Chromium browser smoke test not run successfully because the Playwright Chromium binary is not installed in this environment
- `cargo xtask check` reached typecheck but was blocked by a read-only package-manager temp directory