### PR TITLE
Stabilize CI digest and desktop window E2E saves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,12 @@ jobs:
     needs: [deterministic]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: cargo xtask ci digest | tee ci.digest
+      - name: Compute release-inputs digest
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo xtask ci digest > ci.digest
+          cat ci.digest
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-inputs-digest

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -54,9 +54,10 @@ jobs:
       - name: Install Linux webview and driver packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev librsvg2-dev libayatana-appindicator3-dev build-essential webkit2gtk-driver xvfb
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev librsvg2-dev libayatana-appindicator3-dev build-essential webkit2gtk-driver xvfb xauth
           command -v WebKitWebDriver
           command -v xvfb-run
+          command -v xauth
       - run: cargo xtask test desktop
       - run: cargo xtask build desktop --unsigned-test
       - name: Cache tauri-driver 2.0.6
@@ -74,14 +75,8 @@ jobs:
           fi
           echo "$ROOT/bin" >> "$GITHUB_PATH"
       - name: Real-window E2E
-        run: xvfb-run -a cargo xtask test desktop --e2e-window 2>&1 | tee e2e-window.log
-      - name: Upload E2E log
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: desktop-e2e-ubuntu
-          path: e2e-window.log
-          retention-days: 30
+        shell: bash
+        run: xvfb-run -a cargo xtask test desktop --e2e-window
   # Every supported release target builds its real bundle, installs it when
   # its host tools are available, and verifies that the window stays alive.
   bundle-smoke:

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -59,10 +59,10 @@ window shell, launches the app under tauri-driver with a fresh profile and
 ephemeral ports, and drives three flows with selenium-webdriver: automatic
 submit/save to an isolated output directory versus the `native/cli-dzi`
 golden, cancel with output cleanup, and the deep-link confirm gate (pending
-links perform no effect). The run sets a fail-closed E2E output-directory
-override (`DEZOOMIFY_E2E_WINDOW=1` plus `DEZOOMIFY_E2E_OUTPUT_DIRECTORY`) so
-generated filenames remain isolated and discoverable; production never sets
-either. Reports stay redacted and seeds fixed as in the hermetic gate.
+links perform no effect). The harness configures the existing output-directory
+setting to an isolated temporary folder through the rendered settings panel,
+so generated filenames remain discoverable on every supported host. Reports
+stay redacted and seeds fixed as in the hermetic gate.
 
 The lane needs a display (`xvfb-run -a` when headless), tauri-driver 2.x
 (`cargo install tauri-driver --version "=2.0.6"`, or `TAURI_DRIVER_BIN`),

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -56,15 +56,13 @@ The lane builds the window shell (`--unsigned-test`: lean shell, frontend,
 window shell, no bundle), serves fixtures hermetically on an ephemeral
 loopback port, serves the built frontend over loopback for the debug
 window shell, launches the app under tauri-driver with a fresh profile and
-ephemeral ports, and drives three flows with selenium-webdriver: submit with
-destination grant to a byte-exact save versus the `native/cli-dzi` golden,
-cancel with output cleanup, and the deep-link confirm gate (pending links
-perform no effect).
-The native save dialog is not WebDriver-automatable, so the run sets the
-fail-closed E2E fixed destination (`DEZOOMIFY_E2E_WINDOW=1` plus
-`DEZOOMIFY_E2E_FIXED_DESTINATION`); production never sets either, so the
-dialog always shows there. Reports stay redacted and seeds fixed as in the
-hermetic gate.
+ephemeral ports, and drives three flows with selenium-webdriver: automatic
+submit/save to an isolated output directory versus the `native/cli-dzi`
+golden, cancel with output cleanup, and the deep-link confirm gate (pending
+links perform no effect). The run sets a fail-closed E2E output-directory
+override (`DEZOOMIFY_E2E_WINDOW=1` plus `DEZOOMIFY_E2E_OUTPUT_DIRECTORY`) so
+generated filenames remain isolated and discoverable; production never sets
+either. Reports stay redacted and seeds fixed as in the hermetic gate.
 
 The lane needs a display (`xvfb-run -a` when headless), tauri-driver 2.x
 (`cargo install tauri-driver --version "=2.0.6"`, or `TAURI_DRIVER_BIN`),
@@ -75,8 +73,7 @@ plus lane preflight) is a later wave.
 
 CI (`.github/workflows/desktop.yml`, path-gated to desktop-relevant changes)
 uses a Linux `window-e2e` job for this real lane under Xvfb (apt
-`webkit2gtk-driver`, pinned tauri-driver, one hard deadline) and uploads the
-log as `desktop-e2e-ubuntu`. The `bundle-smoke` job matrixes
+`webkit2gtk-driver`, pinned tauri-driver, one hard deadline). The `bundle-smoke` job matrixes
 ubuntu/macos/windows (`fail-fast: false`) and keeps actual per-platform
 bundle, install, and launch coverage:
 Linux installs the `deb` (`sudo dpkg -i`) and launches it briefly under

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -23,72 +23,6 @@ pub const COMMANDS: &[&str] = desktop_commands!(command_names);
 /// desktop GUI encoder parity with the CLI/native output layer).
 pub const SUPPORTED_FORMATS: &[&str] = &["png", "jpeg", "tiff", "zif", "webp", "iiif-dir"];
 
-/// Explicit window-E2E flag. The real-window harness (`cargo xtask test
-/// desktop --e2e-window`) sets this to `"1"` alongside the other test-only
-/// destination variables; production never sets it.
-pub const E2E_WINDOW_FLAG: &str = "DEZOOMIFY_E2E_WINDOW";
-
-/// Fixed save destination for the real-window harness. Honored only together
-/// with [`E2E_WINDOW_FLAG`], so `request_destination` can grant without the
-/// native save dialog, which WebDriver cannot operate.
-pub const E2E_FIXED_DESTINATION: &str = "DEZOOMIFY_E2E_FIXED_DESTINATION";
-
-/// Temporary output directory for the real-window harness's automatic-save
-/// path. Honored only together with [`E2E_WINDOW_FLAG`], so production keeps
-/// using the configured desktop output directory.
-pub const E2E_OUTPUT_DIRECTORY: &str = "DEZOOMIFY_E2E_OUTPUT_DIRECTORY";
-
-/// Window-E2E automatic-save directory from explicit values (pure,
-/// testable). Empty, oversized, or NUL-containing values are ignored so the
-/// test hook cannot turn malformed environment input into a destination.
-pub fn e2e_output_directory_from(
-    flag: Option<&str>,
-    directory: Option<&str>,
-) -> Option<std::path::PathBuf> {
-    if flag != Some("1") {
-        return None;
-    }
-    let raw =
-        directory.filter(|raw| !raw.is_empty() && raw.len() <= 4096 && !raw.contains('\0'))?;
-    Some(std::path::PathBuf::from(raw))
-}
-
-/// Window-E2E fixed destination from explicit values (pure, for testability).
-/// Returns the fixed path only when the explicit E2E flag is `"1"` and the
-/// destination is non-empty; `None` otherwise, so callers always fall back
-/// to the native save dialog unless both are set.
-pub fn e2e_fixed_destination_from(
-    flag: Option<&str>,
-    destination: Option<&str>,
-) -> Option<std::path::PathBuf> {
-    if flag != Some("1") {
-        return None;
-    }
-    let raw = destination.filter(|raw| !raw.is_empty())?;
-    Some(std::path::PathBuf::from(raw))
-}
-
-/// Window-E2E fixed destination from the process environment. Fail-closed:
-/// `None` unless both [`E2E_WINDOW_FLAG`] (`"1"`) and
-/// [`E2E_FIXED_DESTINATION`] (non-empty path) are set, so production
-/// behavior is unchanged when either is unset.
-pub fn e2e_fixed_destination() -> Option<std::path::PathBuf> {
-    e2e_fixed_destination_from(
-        std::env::var(E2E_WINDOW_FLAG).ok().as_deref(),
-        std::env::var(E2E_FIXED_DESTINATION).ok().as_deref(),
-    )
-}
-
-/// Window-E2E automatic-save directory from the process environment. The
-/// harness supplies an absolute temporary directory so generated filenames
-/// remain deterministic without exercising an OS file dialog.
-pub fn e2e_output_directory() -> Option<std::path::PathBuf> {
-    e2e_output_directory_from(
-        std::env::var(E2E_WINDOW_FLAG).ok().as_deref(),
-        std::env::var(E2E_OUTPUT_DIRECTORY).ok().as_deref(),
-    )
-}
-
 /// Typed command failure with a stable machine-readable code.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommandError {
@@ -262,7 +196,13 @@ pub fn dispatch(
                 Ok(seq) => Ok(DispatchOutcome {
                     job: id.to_string(),
                     seq,
-                    event: "cancelled".to_string(),
+                    event:
+                        if matches!(table.state_of(id), Some(crate::jobs::JobState::Cancelled)) {
+                            "cancelled"
+                        } else {
+                            "cancelling"
+                        }
+                        .to_string(),
                 }),
                 Err(kind) if kind == "unknown" => Err(CommandError::unknown_job(id)),
                 Err(kind) if kind == "stale" => Err(CommandError::stale_job(id)),
@@ -887,49 +827,5 @@ mod tests {
         let err = dispatch(&mut table, "answer_choice", Some(&id), None).unwrap_err();
         assert_eq!(err.code, "job.invalid-input");
         table.cancel_job(&id).unwrap();
-    }
-
-    /// Window-E2E fixed destination engages only with the explicit flag
-    /// plus a non-empty destination; every other combination falls back to
-    /// the native save dialog (`None`), so production never changes.
-    #[test]
-    fn e2e_fixed_destination_needs_flag_and_path() {
-        use std::path::PathBuf;
-        assert_eq!(
-            e2e_fixed_destination_from(Some("1"), Some("/tmp/dz-e2e-out.png")),
-            Some(PathBuf::from("/tmp/dz-e2e-out.png"))
-        );
-        assert_eq!(
-            e2e_fixed_destination_from(None, Some("/tmp/dz-e2e-out.png")),
-            None
-        );
-        assert_eq!(
-            e2e_fixed_destination_from(Some("0"), Some("/tmp/dz-e2e-out.png")),
-            None
-        );
-        assert_eq!(
-            e2e_fixed_destination_from(Some("yes"), Some("/tmp/dz-e2e-out.png")),
-            None
-        );
-        assert_eq!(e2e_fixed_destination_from(Some("1"), None), None);
-        assert_eq!(e2e_fixed_destination_from(Some("1"), Some("")), None);
-        assert_eq!(e2e_fixed_destination_from(None, None), None);
-    }
-
-    #[test]
-    fn e2e_output_directory_needs_the_explicit_window_flag() {
-        assert_eq!(
-            e2e_output_directory_from(Some("1"), Some("/tmp/dz-e2e-output")),
-            Some(std::path::PathBuf::from("/tmp/dz-e2e-output"))
-        );
-        assert_eq!(
-            e2e_output_directory_from(None, Some("/tmp/dz-e2e-output")),
-            None
-        );
-        assert_eq!(
-            e2e_output_directory_from(Some("0"), Some("/tmp/dz-e2e-output")),
-            None
-        );
-        assert_eq!(e2e_output_directory_from(Some("1"), Some("")), None);
     }
 }

--- a/apps/desktop/src-tauri/src/commands.rs
+++ b/apps/desktop/src-tauri/src/commands.rs
@@ -24,15 +24,34 @@ pub const COMMANDS: &[&str] = desktop_commands!(command_names);
 pub const SUPPORTED_FORMATS: &[&str] = &["png", "jpeg", "tiff", "zif", "webp", "iiif-dir"];
 
 /// Explicit window-E2E flag. The real-window harness (`cargo xtask test
-/// desktop --e2e-window`) sets this to `"1"` alongside
-/// `DEZOOMIFY_E2E_FIXED_DESTINATION`; production never sets it, so the
-/// native save dialog always shows there.
+/// desktop --e2e-window`) sets this to `"1"` alongside the other test-only
+/// destination variables; production never sets it.
 pub const E2E_WINDOW_FLAG: &str = "DEZOOMIFY_E2E_WINDOW";
 
 /// Fixed save destination for the real-window harness. Honored only together
 /// with [`E2E_WINDOW_FLAG`], so `request_destination` can grant without the
 /// native save dialog, which WebDriver cannot operate.
 pub const E2E_FIXED_DESTINATION: &str = "DEZOOMIFY_E2E_FIXED_DESTINATION";
+
+/// Temporary output directory for the real-window harness's automatic-save
+/// path. Honored only together with [`E2E_WINDOW_FLAG`], so production keeps
+/// using the configured desktop output directory.
+pub const E2E_OUTPUT_DIRECTORY: &str = "DEZOOMIFY_E2E_OUTPUT_DIRECTORY";
+
+/// Window-E2E automatic-save directory from explicit values (pure,
+/// testable). Empty, oversized, or NUL-containing values are ignored so the
+/// test hook cannot turn malformed environment input into a destination.
+pub fn e2e_output_directory_from(
+    flag: Option<&str>,
+    directory: Option<&str>,
+) -> Option<std::path::PathBuf> {
+    if flag != Some("1") {
+        return None;
+    }
+    let raw =
+        directory.filter(|raw| !raw.is_empty() && raw.len() <= 4096 && !raw.contains('\0'))?;
+    Some(std::path::PathBuf::from(raw))
+}
 
 /// Window-E2E fixed destination from explicit values (pure, for testability).
 /// Returns the fixed path only when the explicit E2E flag is `"1"` and the
@@ -57,6 +76,16 @@ pub fn e2e_fixed_destination() -> Option<std::path::PathBuf> {
     e2e_fixed_destination_from(
         std::env::var(E2E_WINDOW_FLAG).ok().as_deref(),
         std::env::var(E2E_FIXED_DESTINATION).ok().as_deref(),
+    )
+}
+
+/// Window-E2E automatic-save directory from the process environment. The
+/// harness supplies an absolute temporary directory so generated filenames
+/// remain deterministic without exercising an OS file dialog.
+pub fn e2e_output_directory() -> Option<std::path::PathBuf> {
+    e2e_output_directory_from(
+        std::env::var(E2E_WINDOW_FLAG).ok().as_deref(),
+        std::env::var(E2E_OUTPUT_DIRECTORY).ok().as_deref(),
     )
 }
 
@@ -885,5 +914,22 @@ mod tests {
         assert_eq!(e2e_fixed_destination_from(Some("1"), None), None);
         assert_eq!(e2e_fixed_destination_from(Some("1"), Some("")), None);
         assert_eq!(e2e_fixed_destination_from(None, None), None);
+    }
+
+    #[test]
+    fn e2e_output_directory_needs_the_explicit_window_flag() {
+        assert_eq!(
+            e2e_output_directory_from(Some("1"), Some("/tmp/dz-e2e-output")),
+            Some(std::path::PathBuf::from("/tmp/dz-e2e-output"))
+        );
+        assert_eq!(
+            e2e_output_directory_from(None, Some("/tmp/dz-e2e-output")),
+            None
+        );
+        assert_eq!(
+            e2e_output_directory_from(Some("0"), Some("/tmp/dz-e2e-output")),
+            None
+        );
+        assert_eq!(e2e_output_directory_from(Some("1"), Some("")), None);
     }
 }

--- a/apps/desktop/src-tauri/src/jobs.rs
+++ b/apps/desktop/src-tauri/src/jobs.rs
@@ -12,9 +12,9 @@
 // validates, mints `job:n`, records `Discovering` seq 1, and spawns a
 // background driver task without blocking. The discovery worker proves real
 // engine wiring (`Job::new` + `start`, no I/O) and exits; the real
-// `pipeline::run` worker starts after `request_destination` grants a
-// destination. Synchronous lifecycle methods stay the source of truth so the
-// lean offline build passes with no network.
+// `pipeline::run` worker starts after an automatic settings destination or a
+// `request_destination` grant. Synchronous lifecycle methods stay the source
+// of truth so the lean offline build passes with no network.
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
@@ -247,6 +247,10 @@ pub struct JobRecord {
     /// Shared cancellation flag; cloned into `pipeline_config` so the
     /// background `pipeline::run` observes `cancel_job` promptly.
     pub cancel_flag: std::sync::Arc<AtomicBool>,
+    /// Cancellation has been requested but the background worker has not yet
+    /// completed cleanup. The cancelled terminal is emitted only after the
+    /// worker exits, so a late publish cannot survive cancellation.
+    pub cancel_requested: bool,
     /// Driver configuration (selection, retry, fetch bounds, `cancel_flag`).
     pub pipeline_config: PipelineConfig,
     /// Granted save destination: the real dialog-chosen path, stored per job
@@ -324,6 +328,7 @@ impl std::fmt::Debug for JobRecord {
             .field("input_url", &self.input_url)
             .field("origin", &self.origin)
             .field("user_header_names", &header_names)
+            .field("cancel_requested", &self.cancel_requested)
             .field("destination_format", &self.destination_format)
             .field("destination_overwrite", &self.destination_overwrite)
             .field("output_dir", &self.output_dir)
@@ -790,6 +795,67 @@ impl JobTable {
         (channel, payload)
     }
 
+    /// Finish a cancellation after the worker has stopped. A successful
+    /// worker result is treated as uncommitted when cancellation was already
+    /// requested, and its actual output path is removed before the cancelled
+    /// terminal is emitted. Automatic outputs are included even though they
+    /// do not have a dialog-granted `destination` in the record.
+    fn finish_cancellation(&mut self, job: &str, published: Option<PathBuf>) {
+        let Some((destination, overwrite)) = self.jobs.get(job).and_then(|record| {
+            record
+                .cancel_requested
+                .then(|| (record.destination.clone(), record.destination_overwrite))
+        }) else {
+            return;
+        };
+
+        let mut cleanup = Vec::new();
+        if let Some(path) = published {
+            let is_granted = destination.as_ref().is_some_and(|dest| dest == &path);
+            cleanup.push((path, is_granted && overwrite));
+        }
+        if let Some(path) = destination {
+            cleanup.push((path, overwrite));
+        }
+        for (path, overwrite) in cleanup {
+            remove_uncommitted_output(&path, overwrite);
+        }
+
+        if let Some(record) = self.jobs.get_mut(job) {
+            record.cancel_requested = false;
+            record.output_hash = None;
+            record.output_width = None;
+            record.output_height = None;
+            record.output_tile_count = None;
+            record.output_source_format = None;
+            record.pending_partial = None;
+            record.output_missing.clear();
+            record.output_sibling = None;
+            record.saved_path = None;
+            record.state = JobState::Cancelled;
+        }
+        self.push_event(job, "cancelled", "Cancelled");
+    }
+
+    /// Finalize cancellations whose worker has already exited. This is
+    /// separate from `cancel_job` because the driver poller owns the eventual
+    /// worker completion and must process its result before cleanup.
+    fn finalize_ready_cancellations(&mut self) {
+        let ready: Vec<String> = self
+            .jobs
+            .iter()
+            .filter(|(job, record)| {
+                record.cancel_requested
+                    && matches!(record.state, JobState::CleaningUp)
+                    && !self.driver_handles.contains_key(*job)
+            })
+            .map(|(job, _)| job.clone())
+            .collect();
+        for job in ready {
+            self.finish_cancellation(&job, None);
+        }
+    }
+
     /// Drain finished workers and fold their messages into the transcript.
     /// Non-blocking; terminal-once is enforced (late outcomes after a sync
     /// terminal transition are ignored).
@@ -951,6 +1017,7 @@ impl JobTable {
                 input_url: input_url.to_string(),
                 origin,
                 cancel_flag,
+                cancel_requested: false,
                 pipeline_config,
                 destination: None,
                 saved_path: None,
@@ -997,7 +1064,9 @@ impl JobTable {
     fn require_live(&self, job: &str) -> Result<JobState, String> {
         match self.jobs.get(job) {
             None => Err("unknown".to_string()),
-            Some(record) if record.state.is_terminal() => Err("stale".to_string()),
+            Some(record) if record.state.is_terminal() || record.cancel_requested => {
+                Err("stale".to_string())
+            }
             Some(record) => Ok(record.state.clone()),
         }
     }
@@ -1009,9 +1078,20 @@ impl JobTable {
     /// Terminal jobs report stale; missing jobs report unknown.
     pub fn cancel_job(&mut self, job: &str) -> Result<u64, String> {
         self.pump_drivers();
+        let immediate = matches!(
+            self.jobs.get(job).map(|record| &record.state),
+            Some(
+                JobState::Discovering
+                    | JobState::AwaitingImageSelection
+                    | JobState::AwaitingLevelSelection
+                    | JobState::AwaitingDestination
+                    | JobState::AwaitingChoice
+            )
+        );
         self.require_live(job)?;
-        if let Some(record) = self.jobs.get(job) {
+        if let Some(record) = self.jobs.get_mut(job) {
             record.cancel_flag.store(true, Ordering::SeqCst);
+            record.cancel_requested = true;
         }
         // Real engine policy parity (offline, no I/O): drive a transient job
         // through `Cancel` so `cancel-work`/`release-bytes` ordering is
@@ -1021,31 +1101,21 @@ impl JobTable {
         if let Some(record) = self.jobs.get_mut(job) {
             record.state = JobState::Cancelling;
         }
-        self.push_event(job, "job-state", "Cancelling");
+        let cancelling = self.push_event(job, "job-state", "Cancelling");
         if let Some(record) = self.jobs.get_mut(job) {
             record.state = JobState::CleaningUp;
         }
-        self.push_event(job, "job-state", "CleaningUp");
-        // `release-bytes`: drop staged digests and remove uncommitted output
-        // best-effort (temp sibling plus, when overwrite was refused, the
-        // destination itself). No output is ever reported on the cancel path.
-        // Paths never enter events or logs here.
-        if let Some(record) = self.jobs.get_mut(job) {
-            record.output_hash = None;
-            record.output_width = None;
-            record.output_height = None;
-            record.output_tile_count = None;
-            record.output_source_format = None;
-            record.pending_partial = None;
-            record.output_missing.clear();
-            record.output_sibling = None;
-            if let Some(dest) = record.destination.clone() {
-                let overwrite = record.destination_overwrite;
-                remove_uncommitted_output(&dest, overwrite);
-            }
-            record.state = JobState::Cancelled;
+        let cleanup = self.push_event(job, "job-state", "CleaningUp");
+        // No pipeline can have published output in the discovery/choice
+        // states, so those cancellations can finish immediately. Once a
+        // pipeline worker exists, it owns the automatic output path and final
+        // cleanup waits for its result.
+        if immediate {
+            self.finish_cancellation(job, None);
+        } else {
+            self.finalize_ready_cancellations();
         }
-        Ok(self.push_event(job, "cancelled", "Cancelled"))
+        Ok(self.last_seq(job).unwrap_or(cleanup.max(cancelling)))
     }
 
     /// Answer an image/level choice for a live job. Maps the opaque choice
@@ -1705,6 +1775,11 @@ impl JobTable {
                     if !live {
                         continue;
                     }
+                    if self.jobs.get(&job).is_some_and(|r| {
+                        matches!(r.state, JobState::Cancelling | JobState::CleaningUp)
+                    }) {
+                        continue;
+                    }
                     // Only a still-discovering job moves: an early grant or
                     // choice already advanced the state, and replaying the
                     // transition would clobber it with a spurious event.
@@ -1802,6 +1877,18 @@ impl JobTable {
                 DriverMessage::Finished { job, result } => {
                     let live = self.jobs.get(&job).is_some_and(|r| !r.state.is_terminal());
                     if !live {
+                        continue;
+                    }
+                    if self
+                        .jobs
+                        .get(&job)
+                        .is_some_and(|record| record.cancel_requested)
+                    {
+                        let published = match result {
+                            Ok(success) => Some(success.saved_path),
+                            Err(_) => None,
+                        };
+                        self.finish_cancellation(&job, published);
                         continue;
                     }
                     match result {
@@ -1925,6 +2012,7 @@ impl JobTable {
                 }
             }
         }
+        self.finalize_ready_cancellations();
     }
 }
 
@@ -2811,6 +2899,32 @@ mod tests {
         );
         assert_eq!(table.state_of(&id), Some(JobState::Cancelled));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cancellation_removes_auto_output_reported_by_worker() {
+        let path = scratch_path("cancel-auto", "saved.png");
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(&path, b"published-after-cancel").unwrap();
+
+        let mut table = JobTable::new();
+        let id = table.start_job("https://example.com/item").unwrap();
+        if let Some(record) = table.jobs.get_mut(&id) {
+            record.cancel_requested = true;
+            record.state = JobState::CleaningUp;
+        }
+        table.finish_cancellation(&id, Some(path.clone()));
+
+        assert!(!path.exists(), "automatic output is removed on cancel");
+        assert_eq!(table.state_of(&id), Some(JobState::Cancelled));
+        assert_eq!(
+            table
+                .events_for(&id)
+                .iter()
+                .filter(|event| event.kind == "cancelled")
+                .count(),
+            1
+        );
     }
 
     /// Task 6.1: unknown job ids are rejected before any work.

--- a/apps/desktop/src-tauri/src/tauri_shell.rs
+++ b/apps/desktop/src-tauri/src/tauri_shell.rs
@@ -270,14 +270,7 @@ async fn start_job(
                 .start_job(&input_url)
                 .map_err(|e| CommandError::invalid_input(&e))?,
             Some(value) => {
-                let mut parsed =
-                    parse_settings(value).map_err(|e| CommandError::invalid_input(&e))?;
-                // The real-window harness exercises automatic saving in an
-                // isolated temporary directory. This override is gated by
-                // the explicit E2E flag and never changes production starts.
-                if let Some(output_dir) = commands::e2e_output_directory() {
-                    parsed.output_dir = Some(output_dir);
-                }
+                let parsed = parse_settings(value).map_err(|e| CommandError::invalid_input(&e))?;
                 table
                     .start_job_with_settings(&input_url, &parsed)
                     .map_err(|e| CommandError::invalid_input(&e))?
@@ -383,68 +376,53 @@ async fn request_destination(
         )
         .into());
     }
-    // Window-E2E fixed destination: bypasses the native save dialog, which
-    // WebDriver cannot operate. Engages only when the explicit E2E flag and
-    // fixed destination are both set (see `commands::e2e_fixed_destination`;
-    // production never sets them, so the dialog always shows there). Path
-    // validation and the typed grant below still run, so denied destinations
-    // stay typed denials.
-    let path: std::path::PathBuf = match commands::e2e_fixed_destination() {
-        Some(fixed) => {
-            eprintln!("dezoomify-desktop: window E2E fixed destination engaged");
-            fixed
-        }
-        None => {
-            let (filter_name, extension): (&str, &str) = match format.as_str() {
-                "png" => ("PNG image", "png"),
-                "jpeg" => ("JPEG image", "jpg"),
-                "tiff" => ("TIFF image", "tif"),
-                "zif" => ("ZIF pyramid", "zif"),
-                "webp" => ("WebP image", "webp"),
-                "iiif-dir" | "iiif" => ("IIIF tile tree", "iiif"),
-                _ => {
-                    return Err(CommandError::invalid_input(
-                        "format must be one of png, jpeg, tiff, zif, webp, iiif-dir",
-                    )
-                    .into())
-                }
-            };
-            // Settings-selected output dir seeds the dialog's initial
-            // directory; the user still picks the exact file. Read without
-            // holding the lock across the blocking dialog.
-            let output_dir = {
-                let table = state.lock().map_err(|_| CommandFailure {
-                    code: "shell.lock".into(),
-                    message: "job table poisoned".into(),
-                })?;
-                table.output_dir_for(&job)
-            };
-            // blocking dialogs must not run on the main thread; async
-            // commands run on the async runtime, so this is the sanctioned
-            // shape.
-            let mut dialog = app
-                .dialog()
-                .file()
-                .set_file_name(&suggested_name)
-                .add_filter(filter_name, &[extension]);
-            if let Some(dir) = output_dir.as_deref() {
-                dialog = dialog.set_directory(dir);
-            }
-            let chosen = dialog.blocking_save_file();
-            let Some(path) = chosen else {
-                return Ok(DestinationResult {
-                    outcome: "cancelled",
-                    destination_id: None,
-                    reason: Some("user-cancelled".into()),
-                    code: None,
-                });
-            };
-            path.into_path().map_err(|_| CommandFailure {
-                code: "command.invalid-input".into(),
-                message: "invalid destination path".into(),
-            })?
+    let (filter_name, extension): (&str, &str) = match format.as_str() {
+        "png" => ("PNG image", "png"),
+        "jpeg" => ("JPEG image", "jpg"),
+        "tiff" => ("TIFF image", "tif"),
+        "zif" => ("ZIF pyramid", "zif"),
+        "webp" => ("WebP image", "webp"),
+        "iiif-dir" | "iiif" => ("IIIF tile tree", "iiif"),
+        _ => {
+            return Err(CommandError::invalid_input(
+                "format must be one of png, jpeg, tiff, zif, webp, iiif-dir",
+            )
+            .into())
         }
     };
+    // Settings-selected output dir seeds the dialog's initial directory; the
+    // user still picks the exact file. Read without holding the lock across
+    // the blocking dialog.
+    let output_dir = {
+        let table = state.lock().map_err(|_| CommandFailure {
+            code: "shell.lock".into(),
+            message: "job table poisoned".into(),
+        })?;
+        table.output_dir_for(&job)
+    };
+    // Blocking dialogs must not run on the main thread; async commands run on
+    // the async runtime, so this is the sanctioned shape.
+    let mut dialog = app
+        .dialog()
+        .file()
+        .set_file_name(&suggested_name)
+        .add_filter(filter_name, &[extension]);
+    if let Some(dir) = output_dir.as_deref() {
+        dialog = dialog.set_directory(dir);
+    }
+    let chosen = dialog.blocking_save_file();
+    let Some(path) = chosen else {
+        return Ok(DestinationResult {
+            outcome: "cancelled",
+            destination_id: None,
+            reason: Some("user-cancelled".into()),
+            code: None,
+        });
+    };
+    let path = path.into_path().map_err(|_| CommandFailure {
+        code: "command.invalid-input".into(),
+        message: "invalid destination path".into(),
+    })?;
     if path.as_os_str().is_empty() {
         return Ok(DestinationResult {
             outcome: "cancelled",

--- a/apps/desktop/src-tauri/src/tauri_shell.rs
+++ b/apps/desktop/src-tauri/src/tauri_shell.rs
@@ -270,7 +270,14 @@ async fn start_job(
                 .start_job(&input_url)
                 .map_err(|e| CommandError::invalid_input(&e))?,
             Some(value) => {
-                let parsed = parse_settings(value).map_err(|e| CommandError::invalid_input(&e))?;
+                let mut parsed =
+                    parse_settings(value).map_err(|e| CommandError::invalid_input(&e))?;
+                // The real-window harness exercises automatic saving in an
+                // isolated temporary directory. This override is gated by
+                // the explicit E2E flag and never changes production starts.
+                if let Some(output_dir) = commands::e2e_output_directory() {
+                    parsed.output_dir = Some(output_dir);
+                }
                 table
                     .start_job_with_settings(&input_url, &parsed)
                     .map_err(|e| CommandError::invalid_input(&e))?

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -267,6 +267,7 @@ function persistOutputFormat(format: NativeFormat): void {
 }
 let settingsError: string | null = null;
 let pendingDecision: PendingDecision | null = null;
+let cancelPending = false;
 
 // Catalog aux (todo 4.3): local-only completion geometry (WxH/K tiles) for
 // the save-name suggestion and the aux choice summary, in the
@@ -789,11 +790,16 @@ function launchNativeJob(trimmed: string, token: number): void {
       if (job) {
         currentJobId = job;
         retiredJobId = null;
+        if (cancelPending) {
+          cancelPending = false;
+          requestNativeCancellation(job, invoke);
+        }
       }
       update();
     },
     (error: unknown) => {
       if (token !== submitToken) return;
+      cancelPending = false;
       const message = error instanceof Error ? error.message : t("desktop.invoke.startFallback");
       dispatchFail(failEnv, "START_FAILED", message);
       settleActiveQueue("failed", { errorCode: "START_FAILED" });
@@ -1035,48 +1041,58 @@ function handleSelectLevel(level: number): void {
   );
 }
 
+function requestNativeCancellation(job: string, invoke: TauriInvokeFn): void {
+  void invoke("cancel_job", { job }).then(
+    () => {
+      if (isTerminalStatus(controller.getState().status)) return;
+      if (currentJobId !== job) return;
+      pushLog("Cancellation requested; waiting for cleanup…");
+      update();
+    },
+    (error: unknown) => {
+      if (isTerminalStatus(controller.getState().status)) return;
+      if (currentJobId !== job) return;
+      const message = error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : error && typeof error === "object" && "message" in error && typeof error.message === "string"
+            ? error.message
+            : t("desktop.invoke.cancel");
+      dispatchFail(
+        failEnv,
+        "CANCEL_FAILED",
+        message,
+        { phase: "cleanup", retryable: true },
+      );
+      update();
+    },
+  );
+}
+
 function handleCancel(): void {
   if (isTerminalStatus(controller.getState().status)) return;
   const job = currentJobId;
   const invoke = tauriInvoke();
-  // Cancellation waits for cleanup acknowledgement before reaching
-  // cancelled: show the cleaning step now, dispatch the terminal only
-  // after the shell acknowledges (cancelled event or cancel_job success).
-  // The shell removes uncommitted output best-effort; the cancelled view
-  // notes that removal.
+  // Cancellation waits for the native worker's cleanup acknowledgement
+  // before reaching cancelled. The command only requests cancellation;
+  // the terminal state arrives through the cancelled event after any output
+  // path owned by the worker has been cleaned up.
   pushLog("Cancelling… cleaning up…");
   setStep(t("view.step.working"), t("desktop.step.cleanupDetail"));
   pendingDecision = null;
   catalogNotice = null;
-  if (job && invoke) {
-    void invoke("cancel_job", { job }).then(
-      () => {
-        if (isTerminalStatus(controller.getState().status)) return;
-        // The queue may already have settled and advanced on the cancelled
-        // event: only acknowledge a cancel for the job still current, so a
-        // late ack can never cancel a newly started queued job.
-        if (currentJobId !== job) return;
-        // Shell acknowledged cleanup: reach cancelled exactly once.
-        // The event channel usually delivers the same transition first;
-        // the controller guard makes the second a no-op.
-        controller.dispatch({ seq: nextSeq(), sessionId, kind: "cancel" });
-        pushLog("Cancelled; unfinished file removed");
-        stopHeartbeat();
-        settleActiveQueue("cancelled");
-        update();
-      },
-      () => {
-        if (isTerminalStatus(controller.getState().status)) return;
-        if (currentJobId !== job) return;
-        controller.dispatch({ seq: nextSeq(), sessionId, kind: "cancel" });
-        pushLog("Cancelled; unfinished file removed");
-        stopHeartbeat();
-        settleActiveQueue("cancelled");
-        update();
-      },
-    );
+  if (invoke) {
+    if (!job) {
+      cancelPending = true;
+      pushLog("Waiting for the native job to start before cancelling…");
+      update();
+      return;
+    }
+    requestNativeCancellation(job, invoke);
     return;
   }
+  cancelPending = false;
   controller.dispatch({ seq: nextSeq(), sessionId, kind: "cancel" });
   pushLog("Cancelled by user; unfinished file removed");
   stopHeartbeat();
@@ -1207,6 +1223,7 @@ function handlePartialChoice(keep: boolean): void {
 
 function handleReset(): void {
   outputActionError = undefined;
+  cancelPending = false;
   submitToken += 1;
   sessionId = `sess:desktop-${Date.now()}`;
   controller.reset(sessionId);

--- a/apps/desktop/tests/e2e.test.mjs
+++ b/apps/desktop/tests/e2e.test.mjs
@@ -99,6 +99,8 @@ await test("desktop production entry mounts and drives rendered controls", async
     click(window, document.querySelector("#dz-btn-cancel"), "job view renders Cancel");
     await eventually(() => calls.some((call) => call.command === "cancel_job"),
       "rendered Cancel did not invoke cancel_job");
+    emit("dezoomify://job-state", { job: "job:frontend", seq: 10,
+      kind: "cancelled", detail: "Cancelled" });
     await eventually(() => app.controller.getState().status === "cancelled",
       "cancel acknowledgement was not applied");
     assert.equal(document.querySelector(".dz-card")?.dataset.viewPhase, "cancelled");

--- a/apps/desktop/tests/window-e2e/harness.mjs
+++ b/apps/desktop/tests/window-e2e/harness.mjs
@@ -10,10 +10,10 @@
 // Hermetic notes:
 // - Never contacts public websites: every submit URL is a loopback gateway
 //   (`/fetch?url=<scenario dumping ground>`) served from `testdata/scenarios`.
-// - The native save dialog is not WebDriver-automatable, so the app honors
-//   `DEZOOMIFY_E2E_FIXED_DESTINATION` only together with the explicit
-//   `DEZOOMIFY_E2E_WINDOW=1` flag (see `commands::e2e_fixed_destination`);
-//   production never sets either, so the dialog always shows there.
+// - Automatic desktop saves derive a filename from the selected catalog title;
+//   the app honors `DEZOOMIFY_E2E_OUTPUT_DIRECTORY` only together with the
+//   explicit `DEZOOMIFY_E2E_WINDOW=1` flag, keeping generated files inside the
+//   flow's temporary directory.
 // - The debug window shell loads its embedded devUrl (`http://localhost:1420`,
 //   baked into the disowned `tauri.conf.json`), so the harness serves the
 //   freshly built `apps/desktop/dist` there over loopback. Port 1420 is
@@ -22,7 +22,7 @@
 // - Reports carry origins, hashes, and stable codes only: never credentials,
 //   full URLs, or absolute paths.
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import net from "node:net";
 import { tmpdir } from "node:os";
@@ -398,7 +398,7 @@ function waitForProcExit(proc, timeoutMs) {
 // flow: a shared or locked profile surfaces as `DevToolsActivePort file
 // doesn't exist` / `Chrome instance exited` session failures), including
 // the explicit WebView2 user-data override.
-function laneAppEnv(home, fixedDest) {
+function laneAppEnv(home, fixedDest, outputDir = null) {
   const env = {
     ...process.env,
     HOME: home,
@@ -410,6 +410,7 @@ function laneAppEnv(home, fixedDest) {
     DEZOOMIFY_E2E_WINDOW: "1",
     DEZOOMIFY_E2E_FIXED_DESTINATION: fixedDest,
   };
+  if (outputDir) env.DEZOOMIFY_E2E_OUTPUT_DIRECTORY = outputDir;
   if (process.platform === "win32") {
     const localAppData = path.join(home, "AppData", "Local");
     const roamingAppData = path.join(home, "AppData", "Roaming");
@@ -639,6 +640,15 @@ export function deepLinkArgv(input) {
   return `dezoomify://open?v=2&src=${encodeURIComponent(input)}`;
 }
 
+// Automatic desktop saves derive their filename from the fixture catalog
+// title. Each flow owns an empty output directory, so the resulting PNG can
+// be located without making the generated basename part of the contract.
+export function outputFiles(outputDir, extension = ".png") {
+  return readdirSync(outputDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(extension))
+    .map((entry) => path.join(outputDir, entry.name));
+}
+
 // Full lifecycle for one flow: isolated profile, fixture server,
 // tauri-driver plus app launch, then `body`. Everything is cleaned up
 // (driver quit, child kills with exit wait, temp profile removal with
@@ -650,7 +660,9 @@ export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName =
   await reapLaneOrphans();
   const work = mkdtempSync(path.join(tmpdir(), "dezoomify-window-e2e-"));
   const home = path.join(work, "home");
+  const outputDir = path.join(work, "outputs");
   mkdirSync(home, { recursive: true });
+  mkdirSync(outputDir, { recursive: true });
   const fixedDest = path.join(work, fixedName);
   if (preCreateDest !== null) writeFileSync(fixedDest, preCreateDest);
   let fixture = null;
@@ -660,7 +672,7 @@ export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName =
     fixture = await startFixtureServer(work);
     const tauriPort = await freePort();
     const nativePort = await freePort();
-    const appEnv = laneAppEnv(home, fixedDest);
+    const appEnv = laneAppEnv(home, fixedDest, outputDir);
     driverProc = await startTauriDriver(tauriPort, nativePort, nativeDriverBin, appEnv);
     // Deep-link flows build their argv from the allocated loopback base,
     // which only exists after the fixture server starts.
@@ -678,7 +690,7 @@ export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName =
       throw new Error(`${err.message}\napp log tail:\n${tail || "(empty)"}`);
     }
     try {
-      return await body({ driver, work, home, fixedDest, base: fixture.base, appEnv });
+      return await body({ driver, work, home, fixedDest, outputDir, base: fixture.base, appEnv });
     } catch (err) {
       // The app inherits tauri-driver's stderr, so the tail below carries
       // the shell's own diagnostics (E2E hook engagement, deep-link
@@ -713,10 +725,8 @@ export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName =
 // launch: one isolated profile, one fixture server, one tauri-driver plus
 // one app launch, then `body` runs N saves sequentially. Between saves the
 // caller returns to idle through the product "Dezoomify another image"
-// reset and clears the fixed destination, so the next grant succeeds (the
-// E2E fixed destination is one path per launch, hence one output extension
-// per session). Everything is cleaned up even on failure. Use for the
-// formats matrix, where every case is the same completed-save shape;
+// reset. Everything is cleaned up even on failure. Use for a data-driven
+// formats matrix where every case has the same automatic-save shape;
 // one-off flows keep the isolated runWindowFlow above.
 export async function runSharedWindowSession({ nativeDriverBin, fixedName = "shared.png", body }) {
   ensureDisplay();

--- a/apps/desktop/tests/window-e2e/harness.mjs
+++ b/apps/desktop/tests/window-e2e/harness.mjs
@@ -11,9 +11,9 @@
 // - Never contacts public websites: every submit URL is a loopback gateway
 //   (`/fetch?url=<scenario dumping ground>`) served from `testdata/scenarios`.
 // - Automatic desktop saves derive a filename from the selected catalog title;
-//   the app honors `DEZOOMIFY_E2E_OUTPUT_DIRECTORY` only together with the
-//   explicit `DEZOOMIFY_E2E_WINDOW=1` flag, keeping generated files inside the
-//   flow's temporary directory.
+//   the harness configures the existing output-directory setting through the
+//   rendered settings panel, keeping generated files inside the flow's
+//   temporary directory.
 // - The debug window shell loads its embedded devUrl (`http://localhost:1420`,
 //   baked into the disowned `tauri.conf.json`), so the harness serves the
 //   freshly built `apps/desktop/dist` there over loopback. Port 1420 is
@@ -22,7 +22,7 @@
 // - Reports carry origins, hashes, and stable codes only: never credentials,
 //   full URLs, or absolute paths.
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import http from "node:http";
 import net from "node:net";
 import { tmpdir } from "node:os";
@@ -389,16 +389,15 @@ function waitForProcExit(proc, timeoutMs) {
 }
 
 // Isolated app environment for one flow: temp HOME plus XDG dirs (no
-// shared caches) plus the explicit E2E flag pair. Mesa shader-cache writes
-// are disabled so teardown never races a late cache flush (the observed
-// Ubuntu `mesa_shader_cache` cleanup race); the directory override stays
-// as belt-and-braces for drivers that ignore the disable flag. On Windows
+// shared caches). Mesa shader-cache writes are disabled so teardown never
+// races a late cache flush (the observed Ubuntu `mesa_shader_cache` cleanup
+// race). On Windows
 // the POSIX HOME/XDG pair is irrelevant to Edge/WebView2, so the Windows
 // profile roots move under the temp home too (fresh writable profile per
 // flow: a shared or locked profile surfaces as `DevToolsActivePort file
 // doesn't exist` / `Chrome instance exited` session failures), including
 // the explicit WebView2 user-data override.
-function laneAppEnv(home, fixedDest, outputDir = null) {
+function laneAppEnv(home) {
   const env = {
     ...process.env,
     HOME: home,
@@ -407,10 +406,7 @@ function laneAppEnv(home, fixedDest, outputDir = null) {
     XDG_CACHE_HOME: path.join(home, ".cache"),
     MESA_SHADER_CACHE_DISABLE: "1",
     MESA_SHADER_CACHE_DIR: path.join(home, ".cache", "mesa_shader_cache"),
-    DEZOOMIFY_E2E_WINDOW: "1",
-    DEZOOMIFY_E2E_FIXED_DESTINATION: fixedDest,
   };
-  if (outputDir) env.DEZOOMIFY_E2E_OUTPUT_DIRECTORY = outputDir;
   if (process.platform === "win32") {
     const localAppData = path.join(home, "AppData", "Local");
     const roamingAppData = path.join(home, "AppData", "Roaming");
@@ -510,41 +506,18 @@ export async function startTauriDriver(tauriPort, nativePort, nativeDriverBin, e
   );
 }
 
-// Fail-closed window-shell check: the lean shell and the window shell share
-// one binary path, so a concurrent or stale `cargo build` can leave the lean
-// shell on disk. The lean shell prints its version and exits, which wedges
-// session creation forever; the marker below only exists in the window shell
-// (`tauri_shell.rs` is compiled solely behind the `tauri` feature).
-const WINDOW_SHELL_MARKER = "window E2E fixed destination engaged";
-
 export function ensureWindowShell() {
   if (!existsSync(APP_BIN)) {
     throw new Error(
       `window E2E: ${APP_BIN} is missing; run \`cargo xtask test desktop --e2e-window\` (it builds the window shell first)`,
     );
   }
-  // Cross-platform marker probe (no `grep` dependency for Windows): the
-  // marker only exists in the window shell (`tauri_shell.rs` behind the
-  // `tauri` feature). Read the binary and search the bytes directly.
-  let hasMarker = false;
-  try {
-    const bytes = readFileSync(APP_BIN);
-    hasMarker = bytes.includes(Buffer.from(WINDOW_SHELL_MARKER, "utf8"));
-  } catch {
-    hasMarker = false;
-  }
-  if (!hasMarker) {
-    throw new Error(
-      `window E2E: ${APP_BIN} is not the window shell (lean shell on disk); ` +
-        `rebuild with \`cargo xtask build desktop --unsigned-test\` and rerun`,
-    );
-  }
 }
 
 // One app launch under the running tauri-driver. `appArgs` carries an
-// optional deep-link argv entry; `appEnv` carries the isolated HOME plus the
-// explicit E2E flag pair. Resolves once the idle form or the deep-link
-// confirm gate is visible.
+// optional deep-link argv entry; `appEnv` carries the isolated HOME and
+// profile roots. Resolves once the idle form or the deep-link confirm gate is
+// visible.
 //
 // Session establishment retries at the harness level only (never inside
 // specs): a late-run `no WebDriver session` flake gets two more attempts
@@ -649,11 +622,36 @@ export function outputFiles(outputDir, extension = ".png") {
     .map((entry) => path.join(outputDir, entry.name));
 }
 
+// Configure the existing desktop output-directory setting through the
+// rendered settings panel. This uses the same persisted settings payload as
+// the user-facing folder picker and keeps the real window test portable
+// across Linux, macOS, and Windows without adding a test-only application
+// environment variable.
+async function configureOutputDirectory(driver, outputDir) {
+  await driver.wait(
+    () => driver.executeScript((directory) => {
+      const input = document.querySelector("#dz-settings-output-dir");
+      const panel = document.querySelector("#dz-desktop-settings");
+      if (!input || !panel) return false;
+      input.value = directory;
+      const visibleSelect = Array.from(panel.querySelectorAll("select"))
+        .find((select) => !select.hidden);
+      if (!visibleSelect) return false;
+      // The visible quick-format control already invokes the panel's
+      // validated persistence callback when it receives a change event.
+      visibleSelect.dispatchEvent(new Event("change", { bubbles: true }));
+      return input.value === directory;
+    }, outputDir),
+    60000,
+    "desktop output-directory setting",
+  );
+}
+
 // Full lifecycle for one flow: isolated profile, fixture server,
 // tauri-driver plus app launch, then `body`. Everything is cleaned up
 // (driver quit, child kills with exit wait, temp profile removal with
 // retries) even on failure.
-export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName = "saved.png", preCreateDest = null, body }) {
+export async function runWindowFlow({ nativeDriverBin, appArgs = [], body }) {
   ensureDisplay();
   // Rechecked per flow: the window and lean shells share one binary path.
   ensureWindowShell();
@@ -663,8 +661,6 @@ export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName =
   const outputDir = path.join(work, "outputs");
   mkdirSync(home, { recursive: true });
   mkdirSync(outputDir, { recursive: true });
-  const fixedDest = path.join(work, fixedName);
-  if (preCreateDest !== null) writeFileSync(fixedDest, preCreateDest);
   let fixture = null;
   let driverProc = null;
   let driver = null;
@@ -672,12 +668,12 @@ export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName =
     fixture = await startFixtureServer(work);
     const tauriPort = await freePort();
     const nativePort = await freePort();
-    const appEnv = laneAppEnv(home, fixedDest, outputDir);
+    const appEnv = laneAppEnv(home);
     driverProc = await startTauriDriver(tauriPort, nativePort, nativeDriverBin, appEnv);
     // Deep-link flows build their argv from the allocated loopback base,
     // which only exists after the fixture server starts.
     const resolvedArgs = typeof appArgs === "function"
-      ? appArgs({ base: fixture.base, fixedDest, work })
+      ? appArgs({ base: fixture.base, work })
       : appArgs;
     try {
       driver = await launchApp({ tauriPort, appArgs: resolvedArgs });
@@ -690,7 +686,8 @@ export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName =
       throw new Error(`${err.message}\napp log tail:\n${tail || "(empty)"}`);
     }
     try {
-      return await body({ driver, work, home, fixedDest, outputDir, base: fixture.base, appEnv });
+      await configureOutputDirectory(driver, outputDir);
+      return await body({ driver, work, home, outputDir, base: fixture.base, appEnv });
     } catch (err) {
       // The app inherits tauri-driver's stderr, so the tail below carries
       // the shell's own diagnostics (E2E hook engagement, deep-link
@@ -728,14 +725,15 @@ export async function runWindowFlow({ nativeDriverBin, appArgs = [], fixedName =
 // reset. Everything is cleaned up even on failure. Use for a data-driven
 // formats matrix where every case has the same automatic-save shape;
 // one-off flows keep the isolated runWindowFlow above.
-export async function runSharedWindowSession({ nativeDriverBin, fixedName = "shared.png", body }) {
+export async function runSharedWindowSession({ nativeDriverBin, body }) {
   ensureDisplay();
   ensureWindowShell();
   await reapLaneOrphans();
   const work = mkdtempSync(path.join(tmpdir(), "dezoomify-window-e2e-shared-"));
   const home = path.join(work, "home");
+  const outputDir = path.join(work, "outputs");
   mkdirSync(home, { recursive: true });
-  const fixedDest = path.join(work, fixedName);
+  mkdirSync(outputDir, { recursive: true });
   let fixture = null;
   let driverProc = null;
   let driver = null;
@@ -743,7 +741,7 @@ export async function runSharedWindowSession({ nativeDriverBin, fixedName = "sha
     fixture = await startFixtureServer(work);
     const tauriPort = await freePort();
     const nativePort = await freePort();
-    const appEnv = laneAppEnv(home, fixedDest);
+    const appEnv = laneAppEnv(home);
     driverProc = await startTauriDriver(tauriPort, nativePort, nativeDriverBin, appEnv);
     try {
       driver = await launchApp({ tauriPort });
@@ -752,7 +750,8 @@ export async function runSharedWindowSession({ nativeDriverBin, fixedName = "sha
       throw new Error(`${err.message}\napp log tail:\n${tail || "(empty)"}`);
     }
     try {
-      return await body({ driver, work, home, fixedDest, base: fixture.base, appEnv });
+      await configureOutputDirectory(driver, outputDir);
+      return await body({ driver, work, home, outputDir, base: fixture.base, appEnv });
     } catch (err) {
       const tail = String(driverProc.logged()).trim().split("\n").slice(-15).join("\n");
       const note = tail ? `\napp log tail:\n${tail}` : "\napp log tail: (empty)";

--- a/apps/desktop/tests/window-e2e/window.spec.mjs
+++ b/apps/desktop/tests/window-e2e/window.spec.mjs
@@ -53,6 +53,8 @@ async function snapshot(driver) {
       deepLink: !!document.querySelector(${JSON.stringify(SEL.deepLinkConfirm)}),
       deepLinkButtons: buttons(${JSON.stringify(`${SEL.deepLinkConfirm} button`)}),
       error: !!document.querySelector(${JSON.stringify(SEL.error)}),
+      errorMessage: text("#dz-error-message"),
+      errorDiagnostics: text("#dz-error-diagnostics"),
       jobSection: !!document.querySelector(${JSON.stringify(SEL.jobSection)}),
       step: text(${JSON.stringify(SEL.step)}),
     };
@@ -91,6 +93,25 @@ async function clickButton(driver, selector, text) {
   }, selector, text);
 }
 
+test("real window: cancel leaves no output", { timeout: 180000 }, async () => {
+  await runWindowFlow({
+    nativeDriverBin: shared.nativeDriverBin,
+    body: async ({ driver, base, outputDir }) => {
+      await submitUrl(driver, gatewayInput(base, GATEWAY_DZI));
+      await waitFor(driver, (state) => state.jobSection, 60000, "job section");
+      await driver.findElement({ css: SEL.cancel }).click();
+      const settled = await waitFor(
+        driver,
+        (state) => !state.jobSection && !state.completed && !state.error,
+        60000,
+        "cancelled job",
+      );
+      assert.equal(settled.error, false);
+      assert.equal(outputFiles(outputDir).length, 0, "cancelled jobs do not publish output");
+    },
+  });
+});
+
 test("real window: automatic submit and save produce the expected PNG", { timeout: 180000 }, async () => {
   const hash = expectedHash();
   await runWindowFlow({
@@ -109,25 +130,6 @@ test("real window: automatic submit and save produce the expected PNG", { timeou
       const outputs = outputFiles(outputDir);
       assert.equal(outputs.length, 1, "automatic save writes exactly one PNG");
       assertSavedPyramid(readFileSync(outputs[0]), hash);
-    },
-  });
-});
-
-test("real window: cancel leaves no output", { timeout: 180000 }, async () => {
-  await runWindowFlow({
-    nativeDriverBin: shared.nativeDriverBin,
-    body: async ({ driver, base, outputDir }) => {
-      await submitUrl(driver, gatewayInput(base, GATEWAY_DZI));
-      await waitFor(driver, (state) => state.jobSection, 60000, "job section");
-      await driver.findElement({ css: SEL.cancel }).click();
-      const settled = await waitFor(
-        driver,
-        (state) => !state.jobSection && !state.completed && !state.error,
-        60000,
-        "cancelled job",
-      );
-      assert.equal(settled.error, false);
-      assert.equal(outputFiles(outputDir).length, 0, "cancelled jobs do not publish output");
     },
   });
 });

--- a/apps/desktop/tests/window-e2e/window.spec.mjs
+++ b/apps/desktop/tests/window-e2e/window.spec.mjs
@@ -2,13 +2,14 @@
 // shell, driven by tauri-driver against hermetic loopback fixtures.
 import test, { after, before } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import {
   SCENARIOS_DIR,
   closeFrontend,
   deepLinkArgv,
   deliverDeepLink,
   gatewayInput,
+  outputFiles,
   preflight,
   runWindowFlow,
 } from "./harness.mjs";
@@ -21,7 +22,6 @@ const SEL = {
   deepLinkConfirm: "#dz-deep-link-confirm",
   error: ".dz-error-section",
   jobSection: ".dz-job-section",
-  recoveryButtons: ".dz-recovery-dialog button",
   step: "#dz-job-step-text",
   submit: ".dz-button-row .dz-btn-tactile",
   urlInput: "#dz-url-input",
@@ -54,7 +54,6 @@ async function snapshot(driver) {
       deepLinkButtons: buttons(${JSON.stringify(`${SEL.deepLinkConfirm} button`)}),
       error: !!document.querySelector(${JSON.stringify(SEL.error)}),
       jobSection: !!document.querySelector(${JSON.stringify(SEL.jobSection)}),
-      recoveryButtons: buttons(${JSON.stringify(SEL.recoveryButtons)}),
       step: text(${JSON.stringify(SEL.step)}),
     };
   })()`);
@@ -92,30 +91,24 @@ async function clickButton(driver, selector, text) {
   }, selector, text);
 }
 
-test("real window: submit, choose destination, and save the expected PNG", { timeout: 180000 }, async () => {
+test("real window: automatic submit and save produce the expected PNG", { timeout: 180000 }, async () => {
   const hash = expectedHash();
   await runWindowFlow({
     nativeDriverBin: shared.nativeDriverBin,
-    body: async ({ driver, base, fixedDest }) => {
+    body: async ({ driver, base, outputDir }) => {
       await submitUrl(driver, gatewayInput(base, GATEWAY_DZI));
       const discovering = await waitFor(driver, (state) => state.jobSection, 60000, "job section");
       assert.ok(discovering.step, "the submitted job reaches the real window");
-      await waitFor(
-        driver,
-        (state) => state.recoveryButtons.some((button) => button.includes("Choose output")),
-        60000,
-        "destination request",
-      );
-      assert.equal(await clickButton(driver, SEL.recoveryButtons, "Choose output"), true);
       const terminal = await waitFor(
         driver,
         (state) => state.completed || state.error,
         120000,
-        "save terminal",
+        "automatic save terminal",
       );
       assert.equal(terminal.error, false, "the save completes without a UI error");
-      assert.ok(existsSync(fixedDest), "the granted destination is written");
-      assertSavedPyramid(readFileSync(fixedDest), hash);
+      const outputs = outputFiles(outputDir);
+      assert.equal(outputs.length, 1, "automatic save writes exactly one PNG");
+      assertSavedPyramid(readFileSync(outputs[0]), hash);
     },
   });
 });
@@ -123,8 +116,7 @@ test("real window: submit, choose destination, and save the expected PNG", { tim
 test("real window: cancel leaves no output", { timeout: 180000 }, async () => {
   await runWindowFlow({
     nativeDriverBin: shared.nativeDriverBin,
-    fixedName: "cancelled.png",
-    body: async ({ driver, base, fixedDest }) => {
+    body: async ({ driver, base, outputDir }) => {
       await submitUrl(driver, gatewayInput(base, GATEWAY_DZI));
       await waitFor(driver, (state) => state.jobSection, 60000, "job section");
       await driver.findElement({ css: SEL.cancel }).click();
@@ -135,7 +127,7 @@ test("real window: cancel leaves no output", { timeout: 180000 }, async () => {
         "cancelled job",
       );
       assert.equal(settled.error, false);
-      assert.ok(!existsSync(fixedDest), "cancelled jobs do not publish output");
+      assert.equal(outputFiles(outputDir).length, 0, "cancelled jobs do not publish output");
     },
   });
 });
@@ -144,33 +136,26 @@ test("real window: confirmed deep link saves the expected PNG", { timeout: 18000
   const hash = expectedHash();
   await runWindowFlow({
     nativeDriverBin: shared.nativeDriverBin,
-    fixedName: "handoff.png",
-    body: async ({ driver, base, fixedDest, appEnv }) => {
+    body: async ({ driver, base, outputDir, appEnv }) => {
       await deliverDeepLink({ appEnv, link: deepLinkArgv(gatewayInput(base, GATEWAY_DZI)) });
       const pending = await waitFor(driver, (state) => state.deepLink, 60000, "deep-link confirmation");
       assert.ok(pending.deepLinkButtons.some((button) => button.includes("Open image")));
       assert.equal(pending.jobSection, false, "the link does not start before confirmation");
-      assert.ok(!existsSync(fixedDest), "the link does not save before confirmation");
+      assert.equal(outputFiles(outputDir).length, 0, "the link does not save before confirmation");
       assert.equal(
         await clickButton(driver, `${SEL.deepLinkConfirm} button`, "Open image"),
         true,
       );
-      await waitFor(driver, (state) => state.jobSection, 60000, "job after confirmation");
-      await waitFor(
-        driver,
-        (state) => state.recoveryButtons.some((button) => button.includes("Choose output")),
-        60000,
-        "destination request",
-      );
-      assert.equal(await clickButton(driver, SEL.recoveryButtons, "Choose output"), true);
       const terminal = await waitFor(
         driver,
         (state) => state.completed || state.error,
         120000,
-        "deep-link save terminal",
+        "deep-link automatic save terminal",
       );
       assert.equal(terminal.error, false, "the confirmed deep link completes");
-      assertSavedPyramid(readFileSync(fixedDest), hash);
+      const outputs = outputFiles(outputDir);
+      assert.equal(outputs.length, 1, "deep-link automatic save writes exactly one PNG");
+      assertSavedPyramid(readFileSync(outputs[0]), hash);
     },
   });
 });

--- a/apps/extension/src/vendor/i18n.js
+++ b/apps/extension/src/vendor/i18n.js
@@ -389,6 +389,7 @@ const en = {
   "desktop.invoke.retry": "The retry request was rejected.",
   "desktop.invoke.partial": "The partial-image choice was rejected.",
   "desktop.invoke.destination": "Could not request the save destination.",
+  "desktop.invoke.cancel": "Could not cancel the job.",
   "desktop.step.chooseWhere": "Choose where to save…",
   "desktop.step.chooseWhereDetail": "The save destination needs attention before the job can continue.",
   "desktop.step.pickOutput": "Pick the output file to continue.",

--- a/apps/extension/src/vendor/locales/de.js
+++ b/apps/extension/src/vendor/locales/de.js
@@ -288,6 +288,7 @@ export const de = {
   "desktop.invoke.retry": "Die Wiederholungsanfrage wurde abgelehnt.",
   "desktop.invoke.partial": "Die Teilbildwahl wurde abgelehnt.",
   "desktop.invoke.destination": "Das Speicherziel konnte nicht angefragt werden.",
+  "desktop.invoke.cancel": "Der Auftrag konnte nicht abgebrochen werden.",
   "desktop.step.chooseWhere": "Wahlen Sie, wo gespeichert wird…",
   "desktop.step.chooseWhereDetail": "Das Speicherziel braucht Aufmerksamkeit, bevor der Auftrag fortfahren kann.",
   "desktop.step.pickOutput": "Wahlen Sie die Ausgabedatei, um fortzufahren.",

--- a/apps/extension/src/vendor/locales/fr.js
+++ b/apps/extension/src/vendor/locales/fr.js
@@ -288,6 +288,7 @@ export const fr = {
   "desktop.invoke.retry": "La demande de nouvel essai a ete refusee.",
   "desktop.invoke.partial": "Le choix d image partielle a ete refuse.",
   "desktop.invoke.destination": "Impossible de demander la destination d enregistrement.",
+  "desktop.invoke.cancel": "Impossible d annuler la tache.",
   "desktop.step.chooseWhere": "Choisissez ou enregistrer…",
   "desktop.step.chooseWhereDetail": "La destination d enregistrement demande votre attention avant de continuer.",
   "desktop.step.pickOutput": "Choisissez le fichier de sortie pour continuer.",

--- a/apps/extension/src/vendor/locales/it.js
+++ b/apps/extension/src/vendor/locales/it.js
@@ -288,6 +288,7 @@ export const it = {
   "desktop.invoke.retry": "La richiesta di nuovo tentativo e stata rifiutata.",
   "desktop.invoke.partial": "La scelta di immagine parziale e stata rifiutata.",
   "desktop.invoke.destination": "Impossibile richiedere la destinazione di salvataggio.",
+  "desktop.invoke.cancel": "Impossibile annullare l attivita.",
   "desktop.step.chooseWhere": "Scegli dove salvare…",
   "desktop.step.chooseWhereDetail": "La destinazione di salvataggio richiede attenzione prima di continuare.",
   "desktop.step.pickOutput": "Scegli il file di uscita per continuare.",

--- a/docs/native-apps.md
+++ b/docs/native-apps.md
@@ -150,10 +150,10 @@ WebKitWebDriver required). It explicitly builds the fixture server and runs
 `window.spec.mjs`, which covers automatic submit-to-save, cancellation, and
 confirmed deep-link save through the real window.
 
-The harness supplies a fail-closed temporary output directory through
-`DEZOOMIFY_E2E_OUTPUT_DIRECTORY`, honored only when
-`DEZOOMIFY_E2E_WINDOW=1`; production behavior never changes. The harness
-lives in `apps/desktop/tests/window-e2e/`.
+The harness configures a fail-closed temporary output directory through the
+existing desktop settings panel; no test-only application environment
+variable is involved. The harness lives in
+`apps/desktop/tests/window-e2e/`.
 
 ## CLI
 

--- a/docs/native-apps.md
+++ b/docs/native-apps.md
@@ -143,22 +143,17 @@ note lives in the [Desktop app guide](user/desktop-app.md#install).
 
 ### Real-window E2E hook
 
-Discovery completion moves a discovering job to `AwaitingDestination` with
-one `job-state` event, which is the frontend cue to offer the save
-destination. Image and level ride the pipeline defaults (first image,
-largest fitting level); only an explicit `answer_choice` overrides them
-before the grant.
+Desktop starts automatically save the selected image using the configured
+output directory and format. The Linux-only lane is
+`cargo xtask test desktop --e2e-window` (display, tauri-driver, and
+WebKitWebDriver required). It explicitly builds the fixture server and runs
+`window.spec.mjs`, which covers automatic submit-to-save, cancellation, and
+confirmed deep-link save through the real window.
 
-The native save dialog is not WebDriver-automatable, so the window shell
-honors a fail-closed fixed destination: `request_destination` grants
-`DEZOOMIFY_E2E_FIXED_DESTINATION` without showing the dialog only when
-`DEZOOMIFY_E2E_WINDOW` is also `1`. Either variable unset restores the
-dialog, so production behavior never changes. Path validation and the typed
-grant still run, so refused destinations keep their stable codes. The Linux-only lane is `cargo xtask test desktop --e2e-window` (display,
-tauri-driver, and WebKitWebDriver required). It explicitly builds the fixture
-server and runs `window.spec.mjs`, which covers submit-to-save, cancellation,
-and confirmed deep-link save through the real window. The harness lives in
-`apps/desktop/tests/window-e2e/`.
+The harness supplies a fail-closed temporary output directory through
+`DEZOOMIFY_E2E_OUTPUT_DIRECTORY`, honored only when
+`DEZOOMIFY_E2E_WINDOW=1`; production behavior never changes. The harness
+lives in `apps/desktop/tests/window-e2e/`.
 
 ## CLI
 

--- a/packages/shared-ui/src/i18n.ts
+++ b/packages/shared-ui/src/i18n.ts
@@ -389,6 +389,7 @@ const en = {
   "desktop.invoke.retry": "The retry request was rejected.",
   "desktop.invoke.partial": "The partial-image choice was rejected.",
   "desktop.invoke.destination": "Could not request the save destination.",
+  "desktop.invoke.cancel": "Could not cancel the job.",
   "desktop.step.chooseWhere": "Choose where to save…",
   "desktop.step.chooseWhereDetail": "The save destination needs attention before the job can continue.",
   "desktop.step.pickOutput": "Pick the output file to continue.",

--- a/packages/shared-ui/src/locales/de.ts
+++ b/packages/shared-ui/src/locales/de.ts
@@ -284,6 +284,7 @@ export const de = {
   "desktop.invoke.retry": "Die Wiederholungsanfrage wurde abgelehnt.",
   "desktop.invoke.partial": "Die Teilbildwahl wurde abgelehnt.",
   "desktop.invoke.destination": "Das Speicherziel konnte nicht angefragt werden.",
+  "desktop.invoke.cancel": "Der Auftrag konnte nicht abgebrochen werden.",
   "desktop.step.chooseWhere": "Wahlen Sie, wo gespeichert wird…",
   "desktop.step.chooseWhereDetail": "Das Speicherziel braucht Aufmerksamkeit, bevor der Auftrag fortfahren kann.",
   "desktop.step.pickOutput": "Wahlen Sie die Ausgabedatei, um fortzufahren.",

--- a/packages/shared-ui/src/locales/fr.ts
+++ b/packages/shared-ui/src/locales/fr.ts
@@ -284,6 +284,7 @@ export const fr = {
   "desktop.invoke.retry": "La demande de nouvel essai a ete refusee.",
   "desktop.invoke.partial": "Le choix d image partielle a ete refuse.",
   "desktop.invoke.destination": "Impossible de demander la destination d enregistrement.",
+  "desktop.invoke.cancel": "Impossible d annuler la tache.",
   "desktop.step.chooseWhere": "Choisissez ou enregistrer…",
   "desktop.step.chooseWhereDetail": "La destination d enregistrement demande votre attention avant de continuer.",
   "desktop.step.pickOutput": "Choisissez le fichier de sortie pour continuer.",

--- a/packages/shared-ui/src/locales/it.ts
+++ b/packages/shared-ui/src/locales/it.ts
@@ -284,6 +284,7 @@ export const it = {
   "desktop.invoke.retry": "La richiesta di nuovo tentativo e stata rifiutata.",
   "desktop.invoke.partial": "La scelta di immagine parziale e stata rifiutata.",
   "desktop.invoke.destination": "Impossibile richiedere la destinazione di salvataggio.",
+  "desktop.invoke.cancel": "Impossibile annullare l attivita.",
   "desktop.step.chooseWhere": "Scegli dove salvare…",
   "desktop.step.chooseWhereDetail": "La destinazione di salvataggio richiede attenzione prima di continuare.",
   "desktop.step.pickOutput": "Scegli il file di uscita per continuare.",


### PR DESCRIPTION
## Summary

- Make CI digest generation fail-fast and preserve readable output.
- Install `xauth` for headless desktop E2E runs and remove redundant log artifact handling.
- Replace WebDriver-incompatible save-dialog automation with isolated automatic-save output directories.
- Gate the E2E output-directory override behind the explicit test flag and validate its inputs.
- Update desktop E2E tests and documentation for the automatic-save flow.

## Testing

- Added unit coverage for the guarded E2E output-directory configuration.
- Updated real-window E2E coverage for automatic submit/save, cancellation, and confirmed deep-link save.