### PR TITLE
fix(web): share protocol catalog selection

### DIFF
--- a/apps/extension/src/modal/modal.ts
+++ b/apps/extension/src/modal/modal.ts
@@ -32,15 +32,16 @@
 import { createSessionFetcher, originOf } from "../runtime/fetch.js";
 import { validateCandidateUrl, redactUrlForLabel } from "../runtime/candidates.js";
 import { requestNativeHandoff, NATIVE_HOST_NAME } from "../runtime/nativeHandoff.js";
-import { pickLevel, BROWSER_MAX_PLAN_TILES } from "../vendor/limits.js";
+import { BROWSER_MAX_PLAN_TILES } from "../vendor/limits.js";
+import { pickEngineSelection } from "../vendor/engine-selection.js";
 import { renderView } from "../vendor/view.js";
 import init, * as wasm from "../wasm/dezoomify-wasm.js";
 
 type JsonObject = Record<string, unknown>;
 type ModalContext = JsonObject & { imageCount?: number; failure?: unknown };
 type JobContextExtra = { url?: string; progress?: { current: number; total: number }; rest?: JsonObject };
-type ImageLevel = { index: number; width?: number; height?: number };
-type CatalogImage = { id: string; levels: ImageLevel[] };
+type ImageLevel = { id: string; width: number; height: number; tileWidth: number; tileHeight: number };
+type CatalogImage = { id: string; readiness: "ready" | "deferred"; levels: ImageLevel[] };
 type Catalog = { images: CatalogImage[] };
 type Tile = { uri: string; x: number; y: number; w?: number; h?: number; processing?: string | null };
 type TilePlan = { kind?: string; uri?: string; canvas: { x: number; y: number }; tiles: Tile[] };
@@ -271,10 +272,11 @@ async function discover(sourceUrl: string, tabOrigin: string): Promise<{ session
 }
 
 async function planLevel(session: wasm.DiscoverySession, image: CatalogImage, tabOrigin: string): Promise<TilePlan> {
-  // Canonical level picking (vendored limits.js, no forked area math).
-  const picked = pickLevel({ levels: image.levels });
-  const level = image.levels.find((candidate) => candidate.index === picked.index) ?? image.levels[0];
-  let plan = JSON.parse(session.levelTiles(image.id, level.index)) as TilePlan;
+  const selection = pickEngineSelection({ images: [image] });
+  if (!selection) throw new Error("catalog has no selectable level");
+  const level = image.levels.find((candidate) => candidate.id === selection.level);
+  if (!level) throw new Error("selected level is absent from catalog");
+  let plan = JSON.parse(session.levelTilesById(selection.image, selection.level)) as TilePlan;
   const fetcher = makeTabFetcher(tabOrigin);
   let guard = 0;
   while (plan.kind === "probe" && guard++ < 5) {
@@ -282,7 +284,7 @@ async function planLevel(session: wasm.DiscoverySession, image: CatalogImage, ta
     if (!plan.uri) throw new Error("probe plan has no URI");
     const out = await fetcher.fetchResource(plan.uri, { userIntent: true });
     const bmp = await createImageBitmap(new Blob([new Uint8Array(out.bytes).slice().buffer]));
-    plan = JSON.parse(session.probeSubmit(image.id, level.index, bmp.width > 0, bmp.width, bmp.height)) as TilePlan;
+    plan = JSON.parse(session.probeSubmitById(selection.image, selection.level, bmp.width > 0, bmp.width, bmp.height)) as TilePlan;
   }
   if (plan.tiles && plan.tiles.length > BROWSER_MAX_PLAN_TILES) {
     throw Object.assign(

--- a/apps/extension/src/vendor/engine-selection.js
+++ b/apps/extension/src/vendor/engine-selection.js
@@ -14,17 +14,11 @@
 // erasable-syntax-only for the browser `.js` mirrors.
 import { BROWSER_LIMITS, probeLimits, safeArea } from "./limits.js";
 
-/** Wire shape of one engine catalog level (see `LevelDto`). */
-
-/** Wire shape of one engine catalog image (see `ImageDto`). */
-
-function levelArea(level                   )                {
-  if (typeof level?.width !== "number" || typeof level?.height !== "number") return null;
+function levelArea(level          )                {
   return safeArea(level.width, level.height);
 }
 
-function levelFits(level                   , limits               )          {
-  if (typeof level?.width !== "number" || typeof level?.height !== "number") return true;
+function levelFits(level          , limits               )          {
   return probeLimits({ width: level.width, height: level.height }, limits).verdict === "ok";
 }
 
@@ -34,11 +28,11 @@ function levelFits(level                   , limits               )          {
  * failure; the engine never guesses silently).
  */
 export function pickEngineSelection(
-  catalog                   ,
+  catalog                        ,
   limits                = BROWSER_LIMITS,
 )                         {
   const images = Array.isArray(catalog?.images) ? catalog.images : [];
-  let bestImage                           = null;
+  let bestImage                  = null;
   let bestImageArea = -1;
   for (const image of images) {
     if (image?.readiness && image.readiness !== "ready") continue;
@@ -49,28 +43,30 @@ export function pickEngineSelection(
       const area = levelArea(level) ?? -1;
       if (area >= imageArea) imageArea = area;
     }
-    if (imageArea < 0) continue;
-    if (imageArea >= bestImageArea) {
+    // Probe-driven and adversarial dimensions may not have a safe area yet.
+    // They remain selectable; declared geometry is evaluated below.
+    if (!bestImage || imageArea >= bestImageArea) {
       bestImage = image;
       bestImageArea = imageArea;
     }
   }
   if (!bestImage) return null;
   const levels = Array.isArray(bestImage.levels) ? bestImage.levels : [];
-  let best                           = null;
+  let best                  = null;
   let bestArea = -1;
-  let smallest                           = null;
+  let smallest                  = null;
   let smallestArea = Number.POSITIVE_INFINITY;
   for (const level of levels) {
     const area = levelArea(level);
-    if (area === null) continue;
-    if (levelFits(level, limits) && area >= bestArea) {
+    const declared = level.width > 0 && level.height > 0;
+    const orderingArea = area ?? Number.POSITIVE_INFINITY;
+    if (declared && levelFits(level, limits) && area !== null && area >= bestArea) {
       best = level;
       bestArea = area;
     }
-    if (area < smallestArea) {
+    if (declared && (smallest === null || orderingArea < smallestArea)) {
       smallest = level;
-      smallestArea = area;
+      smallestArea = orderingArea;
     }
   }
   const chosen = best ?? smallest;

--- a/apps/extension/src/wasm/dezoomify-wasm.d.ts
+++ b/apps/extension/src/wasm/dezoomify-wasm.d.ts
@@ -20,6 +20,8 @@ export class DiscoverySession {
   provideFailure(id: number | string, message: string): void;
   finish(): string;
   levelTiles(image: string | number, level: number): string;
+  levelTilesById(imageId: string, levelId: string): string;
   probeSubmit(image: string | number, level: number, valid: boolean, width: number, height: number): string;
+  probeSubmitById(imageId: string, levelId: string, valid: boolean, width: number, height: number): string;
   applyProcessing(recipe: string, bytes: Uint8Array): Uint8Array;
 }

--- a/apps/extension/tests/unit/limits.test.mjs
+++ b/apps/extension/tests/unit/limits.test.mjs
@@ -65,10 +65,10 @@ test("estimateTileCount parity plus 100k guard semantics", () => {
   assert.ok(ext.estimateTileCount(16384, 16384) <= ext.BROWSER_MAX_PLAN_TILES);
 });
 
-test("modal uses the vendored limits module, no forked area math", () => {
+test("modal uses the shared browser policy, no forked area math", () => {
   const modal = readFileSync(new URL("../../src/modal/modal.ts", import.meta.url), "utf8");
   assert.ok(modal.includes('from "../vendor/limits.js"'), "modal must import the vendored limits module");
-  assert.ok(modal.includes("pickLevel"), "modal must use shared pickLevel");
+  assert.ok(modal.includes('from "../vendor/engine-selection.js"'), "modal must use shared selection");
   assert.ok(modal.includes("BROWSER_MAX_PLAN_TILES"), "modal must enforce the 100k tile cap");
   assert.ok(!modal.includes("MAX_CANVAS_AREA = 16384"), "modal must not keep the forked float area check");
 });

--- a/crates/dezoomify-job/tests/workflows.rs
+++ b/crates/dezoomify-job/tests/workflows.rs
@@ -85,12 +85,12 @@ fn discover_success_minimal() {
     assert_eq!(image["readiness"], "ready");
     assert_eq!(image["width"], 512);
     assert_eq!(image["height"], 512);
-    assert_eq!(image["source_kind"], "grid");
+    assert_eq!(image["sourceKind"], "grid");
     let level = &image["levels"][0];
     // Core normalizes levels to ascending size: the first entry is the
     // smallest level (highest ordinal), the last is the largest.
     assert_eq!(level["id"], "lvl:dzi:0:9");
-    assert_eq!(level["tile_width"], 256);
+    assert_eq!(level["tileWidth"], 256);
 
     // The discovery fetch effect targets the input URL with metadata purpose.
     assert!(host.effects.iter().any(|effect| {

--- a/crates/dezoomify-protocol/src/dto.rs
+++ b/crates/dezoomify-protocol/src/dto.rs
@@ -289,6 +289,7 @@ pub enum Readiness {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LevelDto {
     pub id: LevelId,
     pub width: u64,
@@ -298,6 +299,7 @@ pub struct LevelDto {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ImageDto {
     pub id: ImageId,
     pub label: String,
@@ -1088,5 +1090,37 @@ impl ControlEnvelope {
             protocol: PROTOCOL_VERSION.to_string(),
             body,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_json_matches_the_generated_typescript_field_names() {
+        let catalog = CatalogDto {
+            images: vec![ImageDto {
+                id: "img:test".parse().expect("image id"),
+                label: "Test".into(),
+                format: "test".into(),
+                width: 512,
+                height: 512,
+                readiness: Readiness::Ready,
+                source_kind: "grid".into(),
+                levels: vec![LevelDto {
+                    id: "lvl:test".parse().expect("level id"),
+                    width: 512,
+                    height: 512,
+                    tile_width: 256,
+                    tile_height: 256,
+                }],
+            }],
+        };
+        let value = serde_json::to_value(catalog).expect("catalog serializes");
+        assert_eq!(value["images"][0]["sourceKind"], "grid");
+        assert_eq!(value["images"][0]["levels"][0]["tileWidth"], 256);
+        assert!(value["images"][0].get("source_kind").is_none());
+        assert!(value["images"][0]["levels"][0].get("tile_width").is_none());
     }
 }

--- a/crates/dezoomify-wasm/src/discovery.rs
+++ b/crates/dezoomify-wasm/src/discovery.rs
@@ -10,6 +10,7 @@ use dezoomify_core::core::discovery::{DiscoveryOperation, ResourceFailure, Resou
 use dezoomify_core::core::model::{CatalogEntry, ProcessingRecipe, Request, TileRole};
 use dezoomify_core::core::registry::default_registry;
 use dezoomify_core::core::tile_plan::{Grid, TileSource, TileSourceError};
+use dezoomify_job::projection::project_catalog;
 use serde::Serialize;
 
 use crate::error::{redact, AdapterError, AdapterErrorCode};
@@ -181,10 +182,7 @@ impl DiscoverySession {
         Ok(())
     }
 
-    /// Complete discovery and project the catalog to JSON:
-    /// `{"images":[{"id","title","format","warnings","levels":[...]}]}`
-    /// where each level carries `index`, `title`, `scale`, `warnings`, and
-    /// `imageSize` when the source declares one up front.
+    /// Complete discovery and project the versioned protocol catalog to JSON.
     ///
     /// # Errors
     ///
@@ -201,65 +199,47 @@ impl DiscoverySession {
             .take()
             .ok_or_else(|| AdapterError::new(AdapterErrorCode::WrongState, "no operation"))?;
         let catalog = operation.finish().map_err(discovery_error)?;
-        #[derive(Serialize)]
-        struct LevelDto {
-            index: usize,
-            title: Option<String>,
-            scale: Option<u32>,
-            warnings: Vec<String>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            image_size: Option<PointDto>,
-        }
-        #[derive(Serialize)]
-        struct ImageDto {
-            id: usize,
-            title: Option<String>,
-            format: String,
-            warnings: Vec<String>,
-            levels: Vec<LevelDto>,
-        }
-        #[derive(Serialize)]
-        struct CatalogDto {
-            images: Vec<ImageDto>,
-        }
-        let mut images = Vec::new();
-        for (index, entry) in catalog.entries().iter().enumerate() {
-            match entry {
-                CatalogEntry::Ready(image) => {
-                    let levels = image
-                        .levels
-                        .iter()
-                        .enumerate()
-                        .map(|(level_index, level)| LevelDto {
-                            index: level_index,
-                            title: level.title.clone(),
-                            scale: level.scale_factor,
-                            warnings: level.warnings.clone(),
-                            image_size: level.source.image_size().map(|size| PointDto {
-                                x: size.x,
-                                y: size.y,
-                            }),
-                        })
-                        .collect();
-                    images.push(ImageDto {
-                        id: index,
-                        title: image.title.clone(),
-                        format: image.format.as_str().to_string(),
-                        warnings: image.warnings.clone(),
-                        levels,
-                    });
-                }
-                CatalogEntry::Deferred(_) => {
-                    return Err(AdapterError::new(
-                        AdapterErrorCode::Malformed,
-                        "catalog contains an image whose metadata was not fetched",
-                    ));
-                }
-            }
-        }
+        let projected = project_catalog(&catalog)
+            .map_err(|error| malformed(format!("catalog projection failed: {error}")))?;
         self.catalog = Some(catalog);
-        serde_json::to_string(&CatalogDto { images })
+        serde_json::to_string(&projected)
             .map_err(|e| malformed(format!("catalog projection failed: {e}")))
+    }
+
+    fn indexes_for_ids(
+        &self,
+        image_id: &str,
+        level_id: &str,
+    ) -> Result<(usize, usize), AdapterError> {
+        let catalog = self.catalog.as_ref().ok_or_else(|| {
+            AdapterError::new(AdapterErrorCode::WrongState, "discovery not finished")
+        })?;
+        let projected = project_catalog(catalog)
+            .map_err(|error| malformed(format!("catalog projection failed: {error}")))?;
+        for (image_index, image) in projected.images.iter().enumerate() {
+            if image.id.as_str() != image_id {
+                continue;
+            }
+            if let Some(level_index) = image
+                .levels
+                .iter()
+                .position(|level| level.id.as_str() == level_id)
+            {
+                return Ok((image_index, level_index));
+            }
+            return Err(malformed("level id is not in the selected image"));
+        }
+        Err(malformed("image id is not in the catalog"))
+    }
+
+    /// Project the tile plan of a stable protocol image and level id.
+    pub fn level_tiles_by_id(
+        &mut self,
+        image_id: &str,
+        level_id: &str,
+    ) -> Result<String, AdapterError> {
+        let (image, level) = self.indexes_for_ids(image_id, level_id)?;
+        self.level_tiles(image, level)
     }
 
     /// Project the tile plan of one level. For grid/positioned sources this
@@ -349,6 +329,19 @@ impl DiscoverySession {
         };
         let next = step.submit(observation).map_err(tile_error)?;
         self.advance_probe(image, level, next)
+    }
+
+    /// Continue probing a stable protocol image and level id.
+    pub fn probe_submit_by_id(
+        &mut self,
+        image_id: &str,
+        level_id: &str,
+        ok: bool,
+        width: u32,
+        height: u32,
+    ) -> Result<String, AdapterError> {
+        let (image, level) = self.indexes_for_ids(image_id, level_id)?;
+        self.probe_submit(image, level, ok, width, height)
     }
 
     fn advance_probe(
@@ -530,6 +523,24 @@ mod tests {
         let catalog: serde_json::Value = serde_json::from_str(&catalog).expect("catalog parses");
         assert_eq!(catalog["images"].as_array().expect("images").len(), 1);
         assert_eq!(catalog["images"][0]["format"], "zoomify");
+        assert_eq!(catalog["images"][0]["id"], "img:zoomify:image");
+        assert_eq!(catalog["images"][0]["levels"][0]["tileWidth"], 256);
+
+        let image_id = catalog["images"][0]["id"].as_str().expect("image id");
+        let level_id = catalog["images"][0]["levels"]
+            .as_array()
+            .expect("levels")
+            .iter()
+            .find(|level| level["width"] == 512)
+            .and_then(|level| level["id"].as_str())
+            .expect("512-wide level id");
+        let plan_by_id: serde_json::Value = serde_json::from_str(
+            &session
+                .level_tiles_by_id(image_id, level_id)
+                .expect("stable-id plan"),
+        )
+        .expect("stable-id plan parses");
+        assert_eq!(plan_by_id["canvas"]["x"], 512);
 
         // Largest level: 512x512, 2x2 tiles. Find it by canvas size.
         let mut plan = None;
@@ -546,6 +557,28 @@ mod tests {
         assert_eq!(plan["kind"], "resolved");
         assert_eq!(plan["tiles"].as_array().expect("tiles").len(), 4);
         assert_eq!(plan["tiles"][0]["processing"], "none");
+    }
+
+    #[test]
+    fn krpano_catalog_exposes_declared_geometry_with_protocol_names() {
+        let xml = br#"<krpano><image><flat url="tiles/l%l/%00v/l%l_%00v_%00h.jpg" multires="512,512x844,1152x1898,2176x3586,4352x7172,8832x14554,17664x29110,35328x58220"/></image></krpano>"#;
+        let mut session = DiscoverySession::new("https://example.com/eiffel.xml").expect("session");
+        let need: serde_json::Value =
+            serde_json::from_str(&session.next_need().expect("need")).expect("need parses");
+        session
+            .provide(
+                need["id"].as_u64().expect("id") as usize,
+                xml.to_vec(),
+                None,
+            )
+            .expect("provide");
+        let catalog: serde_json::Value =
+            serde_json::from_str(&session.finish().expect("catalog")).expect("catalog parses");
+        let levels = catalog["images"][0]["levels"].as_array().expect("levels");
+        assert!(levels
+            .iter()
+            .any(|level| level["width"] == 8832 && level["height"] == 14554));
+        assert!(levels.iter().all(|level| level.get("image_size").is_none()));
     }
 
     #[test]
@@ -663,10 +696,7 @@ mod tests {
         let levels = catalog["images"][0]["levels"].as_array().expect("levels");
         assert_eq!(levels.len(), 2);
         // Levels normalize ascending by area: small (512x512) first.
-        assert_eq!(
-            levels[0]["image_size"],
-            serde_json::json!({"x": 512, "y": 512})
-        );
+        assert_eq!(levels[0]["width"], serde_json::json!(512));
 
         let small: serde_json::Value =
             serde_json::from_str(&session.level_tiles(0, 0).expect("small plan"))

--- a/crates/dezoomify-wasm/src/lib.rs
+++ b/crates/dezoomify-wasm/src/lib.rs
@@ -286,6 +286,18 @@ pub mod wasm_api {
                 .map_err(js_error)
         }
 
+        /// Project the tile plan of a stable protocol image and level id.
+        #[wasm_bindgen(js_name = "levelTilesById")]
+        pub fn level_tiles_by_id(
+            &mut self,
+            image_id: String,
+            level_id: String,
+        ) -> Result<String, JsValue> {
+            self.inner
+                .level_tiles_by_id(&image_id, &level_id)
+                .map_err(js_error)
+        }
+
         /// Submit one probe observation; returns the next step or the plan.
         #[wasm_bindgen(js_name = "probeSubmit")]
         pub fn probe_submit(
@@ -298,6 +310,21 @@ pub mod wasm_api {
         ) -> Result<String, JsValue> {
             self.inner
                 .probe_submit(image as usize, level as usize, ok, width, height)
+                .map_err(js_error)
+        }
+
+        /// Continue probing a stable protocol image and level id.
+        #[wasm_bindgen(js_name = "probeSubmitById")]
+        pub fn probe_submit_by_id(
+            &mut self,
+            image_id: String,
+            level_id: String,
+            ok: bool,
+            width: u32,
+            height: u32,
+        ) -> Result<String, JsValue> {
+            self.inner
+                .probe_submit_by_id(&image_id, &level_id, ok, width, height)
                 .map_err(js_error)
         }
 

--- a/docs/browser-runtime.md
+++ b/docs/browser-runtime.md
@@ -41,6 +41,15 @@ deterministic catalog selection for engine hosts lives in
 `engine-selection.ts` (largest ready image, largest level that fits the
 browser canvas, smallest declared level as the fail-fast fallback).
 
+## Catalog boundary
+
+Browser hosts consume the protocol `CatalogDto` with stable `img:` and `lvl:`
+identifiers. The WASM discovery session projects its core catalog through the
+same `dezoomify-job` projection as the job engine, and planning accepts those
+stable identifiers. Browser selection, declared-size preflight, and plan gates
+therefore use one generated wire shape; hosts do not define their own catalog
+or level DTOs.
+
 ## Ordinary image display
 
 For ordinary website tiles with `ProcessingRecipe::None`, the runtime may load through `<img>` and draw into a canvas even when the source taints it. The canvas remains visible, and the user can use the browser's right-click or other user-agent save support where available.

--- a/docs/user/website.md
+++ b/docs/user/website.md
@@ -17,7 +17,7 @@ reading is part of it).
 5. When the picture appears, use the **Save** button (or right-click the
    image and choose *Save image as…*). The file is saved as a PNG.
 
-If a page offers several images, the website saves the first one it finds.
+If a page offers several images, the website saves the largest one it finds.
 It uses the highest resolution that fits in a browser tab.
 There is no list to pick from in the website.
 To choose a different image or the full resolution, use the [desktop app](./desktop-app.md) or the [command-line tool](./command-line.md).

--- a/packages/browser-runtime/src/engine-selection.ts
+++ b/packages/browser-runtime/src/engine-selection.ts
@@ -10,38 +10,18 @@
 // erasable-syntax-only for the browser `.js` mirrors.
 import { BROWSER_LIMITS, probeLimits, safeArea } from "./limits.ts";
 import type { BrowserLimits } from "./types.ts";
-
-/** Wire shape of one engine catalog level (see `LevelDto`). */
-export interface EngineLevelOption {
-  id: string;
-  width?: number;
-  height?: number;
-}
-
-/** Wire shape of one engine catalog image (see `ImageDto`). */
-export interface EngineImageOption {
-  id: string;
-  label?: string;
-  readiness?: string;
-  levels: EngineLevelOption[];
-}
-
-export interface EngineCatalogLike {
-  images: EngineImageOption[];
-}
+import type { CatalogDto, ImageDto, LevelDto } from "../../protocol-ts/src/generated.ts";
 
 export interface EngineSelection {
   image: string;
   level: string;
 }
 
-function levelArea(level: EngineLevelOption): number | null {
-  if (typeof level?.width !== "number" || typeof level?.height !== "number") return null;
+function levelArea(level: LevelDto): number | null {
   return safeArea(level.width, level.height);
 }
 
-function levelFits(level: EngineLevelOption, limits: BrowserLimits): boolean {
-  if (typeof level?.width !== "number" || typeof level?.height !== "number") return true;
+function levelFits(level: LevelDto, limits: BrowserLimits): boolean {
   return probeLimits({ width: level.width, height: level.height }, limits).verdict === "ok";
 }
 
@@ -51,11 +31,11 @@ function levelFits(level: EngineLevelOption, limits: BrowserLimits): boolean {
  * failure; the engine never guesses silently).
  */
 export function pickEngineSelection(
-  catalog: EngineCatalogLike,
+  catalog: CatalogDto | undefined,
   limits: BrowserLimits = BROWSER_LIMITS,
 ): EngineSelection | null {
   const images = Array.isArray(catalog?.images) ? catalog.images : [];
-  let bestImage: EngineImageOption | null = null;
+  let bestImage: ImageDto | null = null;
   let bestImageArea = -1;
   for (const image of images) {
     if (image?.readiness && image.readiness !== "ready") continue;
@@ -66,28 +46,30 @@ export function pickEngineSelection(
       const area = levelArea(level) ?? -1;
       if (area >= imageArea) imageArea = area;
     }
-    if (imageArea < 0) continue;
-    if (imageArea >= bestImageArea) {
+    // Probe-driven and adversarial dimensions may not have a safe area yet.
+    // They remain selectable; declared geometry is evaluated below.
+    if (!bestImage || imageArea >= bestImageArea) {
       bestImage = image;
       bestImageArea = imageArea;
     }
   }
   if (!bestImage) return null;
   const levels = Array.isArray(bestImage.levels) ? bestImage.levels : [];
-  let best: EngineLevelOption | null = null;
+  let best: LevelDto | null = null;
   let bestArea = -1;
-  let smallest: EngineLevelOption | null = null;
+  let smallest: LevelDto | null = null;
   let smallestArea = Number.POSITIVE_INFINITY;
   for (const level of levels) {
     const area = levelArea(level);
-    if (area === null) continue;
-    if (levelFits(level, limits) && area >= bestArea) {
+    const declared = level.width > 0 && level.height > 0;
+    const orderingArea = area ?? Number.POSITIVE_INFINITY;
+    if (declared && levelFits(level, limits) && area !== null && area >= bestArea) {
       best = level;
       bestArea = area;
     }
-    if (area < smallestArea) {
+    if (declared && (smallest === null || orderingArea < smallestArea)) {
       smallest = level;
-      smallestArea = area;
+      smallestArea = orderingArea;
     }
   }
   const chosen = best ?? smallest;

--- a/packages/browser-runtime/src/session.ts
+++ b/packages/browser-runtime/src/session.ts
@@ -19,6 +19,7 @@
 
 import { failure } from "./failure.ts";
 import type { StructuredFailure } from "./failure.ts";
+import type { CatalogDto } from "../../protocol-ts/src/generated.ts";
 
 export { failure };
 export type { StructuredFailure };
@@ -31,23 +32,7 @@ export interface WorkerLike {
   onerror?: ((ev: ErrorEvent) => void) | null;
 }
 
-export interface CatalogLevel {
-  index: number;
-  title?: string;
-  scale?: number;
-  imageSize?: { x: number; y: number };
-}
-
-export interface CatalogImage {
-  id: number;
-  title?: string;
-  format: string;
-  levels: CatalogLevel[];
-}
-
-export interface WebCatalog {
-  images: CatalogImage[];
-}
+export type WebCatalog = CatalogDto;
 
 export interface PlanTile {
   uri: string;
@@ -82,7 +67,7 @@ export interface DiscoveryClientDeps {
 
 export interface DiscoveryClient {
   start(url: string): Promise<WebCatalog>;
-  plan(image: number, level: number): Promise<TilePlan>;
+  plan(image: string, level: string): Promise<TilePlan>;
   process(recipe: string, bytes: ArrayBuffer): Promise<ArrayBuffer>;
   dispose(): void;
 }
@@ -96,8 +81,8 @@ export function createDiscoveryClient(deps: DiscoveryClientDeps): DiscoveryClien
   const { worker } = deps;
   let pending: Pending | null = null;
   let pendingKind: "start" | "plan" | "process" | null = null;
-  let currentImage = 0;
-  let currentLevel = 0;
+  let currentImage = "";
+  let currentLevel = "";
   let disposed = false;
 
   // A worker that never starts (script load failure, corrupted content) would
@@ -250,11 +235,11 @@ export function createDiscoveryClient(deps: DiscoveryClientDeps): DiscoveryClien
 
   return {
     start(url: string): Promise<WebCatalog> {
-      currentImage = 0;
-      currentLevel = 0;
+      currentImage = "";
+      currentLevel = "";
       return send({ type: "start", url }, "start") as Promise<WebCatalog>;
     },
-    plan(image: number, level: number): Promise<TilePlan> {
+    plan(image: string, level: string): Promise<TilePlan> {
       currentImage = image;
       currentLevel = level;
       return send({ type: "plan", image, level }, "plan") as Promise<TilePlan>;

--- a/packages/browser-runtime/test/engine-selection.test.mjs
+++ b/packages/browser-runtime/test/engine-selection.test.mjs
@@ -41,6 +41,22 @@ test("levels beyond the browser canvas fall back to the smallest declared level"
   assert.deepEqual(pickEngineSelection(catalog), { image: "img:0", level: "lvl:small" });
 });
 
+test("krpano Eiffel pyramid selects the largest browser-safe level", () => {
+  const catalog = {
+    images: [image("img:krpano", [
+      level("lvl:0", 512, 512),
+      level("lvl:1", 844, 1152),
+      level("lvl:2", 1898, 2176),
+      level("lvl:3", 3586, 4352),
+      level("lvl:4", 7172, 8832),
+      level("lvl:5", 14554, 8832),
+      level("lvl:6", 29110, 17664),
+      level("lvl:7", 58220, 35328),
+    ])],
+  };
+  assert.deepEqual(pickEngineSelection(catalog), { image: "img:krpano", level: "lvl:5" });
+});
+
 test("ties keep the later image and later level", () => {
   const catalog = {
     images: [

--- a/packages/browser-runtime/test/session.test.mjs
+++ b/packages/browser-runtime/test/session.test.mjs
@@ -113,7 +113,7 @@ test("plan drives probe rounds until the plan resolves", async () => {
     fetchTile: async () => ({ bytes: new ArrayBuffer(8) }),
     probeSize: async () => ({ ok: true, width: 256, height: 256 }),
   });
-  const plan = await client.plan(0, 0);
+  const plan = await client.plan("img:0", "lvl:0");
   assert.equal(probes, 2);
   assert.equal(plan.canvas.x, 512);
   assert.equal(plan.tiles.length, 1);
@@ -196,7 +196,7 @@ test("a second operation is rejected while one is pending", async () => {
   });
   const first = client.start("https://site.test/slow");
   await assert.rejects(
-    () => client.plan(0, 0),
+    () => client.plan("img:0", "lvl:0"),
     (error) => error.code === "CLIENT_BUSY",
   );
   client.dispose();
@@ -242,7 +242,7 @@ test("a stray catalog during a pending plan does not cancel the plan", async () 
     fetchTile: async () => ({ bytes: new ArrayBuffer(1) }),
     probeSize: async () => ({ ok: false, width: 0, height: 0 }),
   });
-  const plan = await client.plan(0, 0);
+  const plan = await client.plan("img:0", "lvl:0");
   assert.equal(plan.canvas.x, 256);
   client.dispose();
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,8 +33,19 @@ import {
   type PlanTile,
   type WebCatalog,
 } from "../packages/browser-runtime/src/session.ts";
-import { probeLimits, safeArea } from "../packages/browser-runtime/src/limits.ts";
-import type { BrowserLimits } from "../packages/browser-runtime/src/types.ts";
+import {
+  BROWSER_LIMITS,
+  BROWSER_MAX_CANVAS_AREA,
+  BROWSER_MAX_CANVAS_SIDE,
+  BROWSER_MAX_PLAN_TILES,
+} from "../packages/browser-runtime/src/limits.ts";
+import {
+  assertDeclaredSizeFitsBrowser,
+  assertPlanFitsBrowser,
+  desktopHandoffLink,
+  mapWorkerLimitExceeded,
+} from "../packages/browser-runtime/src/plan-gates.ts";
+import { pickEngineSelection } from "../packages/browser-runtime/src/engine-selection.ts";
 import {
   cancelAllWeb,
   createWebQueue,
@@ -57,6 +68,10 @@ import {
 // existing website test imports (`test/pick-level.test.mjs` and
 // `test/preview.test.mjs` import from `src/main.ts`).
 export {
+  BROWSER_MAX_CANVAS_AREA,
+  BROWSER_MAX_CANVAS_SIDE,
+  BROWSER_MAX_PLAN_TILES,
+  desktopHandoffLink,
   PREVIEW_MAX_SCALE,
   PREVIEW_MIN_SCALE,
   PREVIEW_ZOOM_STEP,
@@ -151,55 +166,6 @@ function webQueueEnabled(): boolean {
 /** Per-request timeout applied to every individual HTTP request (30 s). */
 export const REQUEST_TIMEOUT_MS = 30000;
 
-/**
- * Largest canvas a browser tab can hold (16384 x 16384, legacy
- * MAX_CANVAS_AREA parity). Level picking never plans above this: gigapixel
- * services (e.g. the 2-gigapixel deepest WMTS matrix of global imagery)
- * would otherwise exhaust worker memory while serializing trillions of
- * tiles and trap the engine. The pre-plan declared-size check below fails
- * fast without calling `client.plan`; the post-plan canvas check enforces
- * the same bound (via `probeLimits`) for levels without declared sizes.
- */
-export const BROWSER_MAX_CANVAS_AREA = 268435456;
-
-/**
- * Browser canvas limits (todo 5.3, overflow-safe). `probeLimits` is the
- * single canvas check: pickLevel, the pre-plan declared-size gate, and the
- * post-plan canvas gate all call it instead of duplicating `width * height`
- * arithmetic (which overflows past MAX_SAFE_INTEGER for gigapixel sizes).
- * No policy widening: 16384 px per side with the legacy area bound.
- */
-export const BROWSER_MAX_CANVAS_SIDE = 16384;
-export const BROWSER_LIMITS: BrowserLimits = {
-  maxWidth: BROWSER_MAX_CANVAS_SIDE,
-  maxHeight: BROWSER_MAX_CANVAS_SIDE,
-  maxArea: BROWSER_MAX_CANVAS_AREA,
-  maxBytes: BROWSER_MAX_CANVAS_AREA * 4,
-};
-
-/**
- * Upper bound on tiles materialized into one website plan (todo 5.3).
- * Mirrors the wasm `MAX_PLAN_TILES` allocation guard: the worker rejects
- * larger plans with `limit-exceeded` before serializing them, and the
- * website's pre-plan estimate plus post-plan cap fail with the same
- * desktop-app guidance. Allocation protection only, not a canvas policy.
- */
-export const BROWSER_MAX_PLAN_TILES = 100_000;
-
-/** Desktop handoff link for images beyond the browser tab (`dezoomify://`).
- * Returns "" for non-http(s) sources (for example local `file:` URLs): the
- * desktop deep link only carries bounded http(s) input, so local files show
- * the local-only note instead of a broken link. */
-export function desktopHandoffLink(sourceUrl: string): string {
-  try {
-    const u = new URL(String(sourceUrl ?? "").trim());
-    if (u.protocol !== "http:" && u.protocol !== "https:") return "";
-  } catch {
-    return "";
-  }
-  return `dezoomify://open?v=2&src=${encodeURIComponent(sourceUrl)}`;
-}
-
 /** True for `file:` URLs pasted into the website input. Local files stay on
  * this computer, so the failed view shows the local-only note (nothing is
  * sent) instead of a deep link. */
@@ -209,38 +175,6 @@ function isLocalFileUrl(urlString: string): boolean {
   } catch {
     return false;
   }
-}
-
-/**
- * Tile-count estimate for a declared size assuming 256 px tiles (todo 5.3).
- * 256 px is the smallest common tile, so the estimate is a conservative
- * upper bound: when it already exceeds `BROWSER_MAX_PLAN_TILES`, any real
- * tile size would still need the desktop app. Overflow-safe: returns null
- * for invalid sizes or when the multiply would exceed MAX_SAFE_INTEGER,
- * which callers treat as over-limit (fail fast, never plan).
- */
-export function estimateTileCount(width: number, height: number, tileSide: number = 256): number | null {
-  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) return null;
-  if (!Number.isInteger(tileSide) || tileSide <= 0) return null;
-  const cols = Math.floor((width + tileSide - 1) / tileSide);
-  const rows = Math.floor((height + tileSide - 1) / tileSide);
-  if (!Number.isSafeInteger(cols) || !Number.isSafeInteger(rows) || cols <= 0 || rows <= 0) return null;
-  if (cols > Number.MAX_SAFE_INTEGER / rows) return null;
-  return cols * rows;
-}
-
-function canvasTooLargeFailure(width: number, height: number, sourceUrl: string, extra?: string) {
-  const handoff = desktopHandoffLink(sourceUrl);
-  const technical = extra
-    ? `canvas ${width}x${height} exceeds the browser limit (${extra}); desktop handoff ${handoff}`
-    : `canvas ${width}x${height} exceeds the browser limit; desktop handoff ${handoff}`;
-  return failure(
-    "PLAN_INVALID",
-    "This image is too large for this browser tab. Use the desktop app for the full-size image.",
-    false,
-    `Open in the desktop app: ${handoff}`,
-    technical,
-  );
 }
 
 /**
@@ -1293,50 +1227,6 @@ function makeClient(): DiscoveryClient {
   });
 }
 
-interface PickedLevel {
-  index: number;
-}
-
-/**
- * Largest declared level that fits the browser canvas wins (overflow-safe
- * via `probeLimits`; same 16384-px / area bound, no policy widening).
- * Levels without a declared size keep the old behavior (last wins): their
- * size is only known after probing, so the pre-plan estimate cannot run
- * and the post-plan `probeLimits` + tile-count cap enforces the bound.
- * When declared levels exist but none fits, the smallest declared level is
- * returned so the pre-plan gate fails fast with desktop-app guidance
- * instead of planning a gigapixel level that exhausts worker memory.
- */
-export function pickLevel(image: { levels: Array<{ index: number; imageSize?: { x: number; y: number } }> }): PickedLevel {
-  let best: PickedLevel | null = null;
-  let bestArea = -1;
-  let smallest: PickedLevel | null = null;
-  let smallestArea = Number.POSITIVE_INFINITY;
-  let sawDeclared = false;
-  let lastUndeclared: PickedLevel | null = null;
-  for (const level of image.levels) {
-    const size = level.imageSize;
-    if (!size) {
-      lastUndeclared = { index: level.index };
-      continue;
-    }
-    sawDeclared = true;
-    const fits = probeLimits({ width: size.x, height: size.y }, BROWSER_LIMITS).verdict === "ok";
-    const area = safeArea(size.x, size.y) ?? Number.POSITIVE_INFINITY;
-    if (fits && area >= bestArea) {
-      best = { index: level.index };
-      bestArea = area;
-    }
-    if (area < smallestArea) {
-      smallest = { index: level.index };
-      smallestArea = area;
-    }
-  }
-  if (best) return best;
-  if (sawDeclared) return smallest ?? { index: 0 };
-  return lastUndeclared ?? { index: 0 };
-}
-
 // Encrypted-tile processing (e.g. Google Arts & Culture XOR-free AES
 // container) goes through the single-pending worker client. Tile fetches
 // run concurrently, so processing calls are serialized here: fetching stays
@@ -1490,7 +1380,6 @@ async function runJob(url: string): Promise<void> {
       );
     }
     pushLog(`Found ${catalog.images.length} image${catalog.images.length === 1 ? "" : "s"}`);
-    const image = catalog.images[0];
     controller.dispatch(
       nextEvent("images-found", { imageCount: catalog.images.length, transport: via }) as never,
     );
@@ -1500,30 +1389,17 @@ async function runJob(url: string): Promise<void> {
       "The website saves the first image automatically; use the desktop app to choose another.",
     );
     controller.dispatch(nextEvent("image-chosen") as never);
-    const level = pickLevel(image);
-    // Pre-plan gate (todo 5.3): declared sizes fail fast with a desktop
-    // handoff link without calling `client.plan`, so the worker never
-    // serializes a trillion-tile plan. Undeclared sizes skip this gate
-    // (probe-driven; size is known only after probing) and rely on the
-    // worker `limit-exceeded` guard plus the post-plan `probeLimits` and
-    // tile-count caps below.
-    const pickedSize = image.levels.find((entry) => entry.index === level.index)?.imageSize;
-    if (pickedSize) {
-      if (probeLimits({ width: pickedSize.x, height: pickedSize.y }, BROWSER_LIMITS).verdict !== "ok") {
-        throw canvasTooLargeFailure(pickedSize.x, pickedSize.y, url);
-      }
-      const estimate = estimateTileCount(pickedSize.x, pickedSize.y);
-      if (estimate === null || estimate > BROWSER_MAX_PLAN_TILES) {
-        throw canvasTooLargeFailure(
-          pickedSize.x,
-          pickedSize.y,
-          url,
-          estimate === null
-            ? "tile-count estimate overflow"
-            : `estimated ${estimate} tiles exceeds the ${BROWSER_MAX_PLAN_TILES}-tile browser plan limit`,
-        );
-      }
+    const selection = pickEngineSelection(catalog, BROWSER_LIMITS);
+    if (!selection) {
+      throw failure("CATALOG_UNSELECTABLE", "The image catalog has no level this browser can select.", false);
     }
+    const image = catalog.images.find((entry) => entry.id === selection.image);
+    const level = image?.levels.find((entry) => entry.id === selection.level);
+    const declared = level && level.width > 0 && level.height > 0
+      ? { x: level.width, y: level.height }
+      : undefined;
+    const declaredFailure = assertDeclaredSizeFitsBrowser(declared, url);
+    if (declaredFailure) throw declaredFailure;
     setStep("Choosing the highest resolution…");
     controller.dispatch(nextEvent("level-chosen") as never);
     setStep("Checking the image size…");
@@ -1532,17 +1408,10 @@ async function runJob(url: string): Promise<void> {
 
     let plan;
     try {
-      plan = await client.plan(image.id, level.index);
+      plan = await client.plan(selection.image, selection.level);
     } catch (error) {
-      // Worker allocation guard (wasm MAX_PLAN_TILES) surfaces as the stable
-      // `limit-exceeded` code inside the detail string; map that stable code
-      // (never UI copy) to the same desktop handoff so probe-driven huge
-      // levels fail as PLAN_INVALID instead of generic WORKER_FAILED.
-      const structured = error as { code?: string; detail?: string; technical?: string };
-      const hay = `${structured?.code ?? ""} ${structured?.detail ?? ""} ${structured?.technical ?? ""}`;
-      if (hay.includes("limit-exceeded")) {
-        throw canvasTooLargeFailure(pickedSize?.x ?? 0, pickedSize?.y ?? 0, url, "tile plan exceeds the browser plan limit");
-      }
+      const mapped = mapWorkerLimitExceeded(error, declared?.x ?? 0, declared?.y ?? 0, url);
+      if (mapped) throw mapped;
       throw error;
     }
     if (token !== jobToken) return;
@@ -1559,26 +1428,8 @@ async function runJob(url: string): Promise<void> {
     }
     const width = plan.canvas ? plan.canvas.x : 0;
     const height = plan.canvas ? plan.canvas.y : 0;
-    if (!(width > 0 && height > 0)) {
-      throw failure(
-        "PLAN_INVALID",
-        "The image size could not be determined.",
-        false,
-        undefined,
-        `invalid tile plan: canvas ${width}x${height}`,
-      );
-    }
-    if (probeLimits({ width, height }, BROWSER_LIMITS).verdict !== "ok") {
-      throw canvasTooLargeFailure(width, height, url);
-    }
-    if (plan.tiles.length > BROWSER_MAX_PLAN_TILES) {
-      throw canvasTooLargeFailure(
-        width,
-        height,
-        url,
-        `${plan.tiles.length} tiles exceeds the ${BROWSER_MAX_PLAN_TILES}-tile browser plan limit`,
-      );
-    }
+    const planFailure = assertPlanFitsBrowser(width, height, plan.tiles.length, url);
+    if (planFailure) throw planFailure;
     canvas.width = width;
     canvas.height = height;
     try {

--- a/src/worker.js
+++ b/src/worker.js
@@ -93,7 +93,7 @@ function pumpNeeds() {
 }
 
 function dispatchPlan(image, level) {
-  const result = JSON.parse(session.levelTiles(image, level));
+  const result = JSON.parse(session.levelTilesById(image, level));
   if (result.kind === "probe") {
     post({ type: "probe", uri: result.uri, headers: result.headers ?? {} });
     return;
@@ -169,7 +169,7 @@ async function handle(msg) {
     case "probe-submit": {
       if (!session) throw Object.assign(new Error("no discovery session"), { code: "WORKER_FAILED" });
       const result = JSON.parse(
-        session.probeSubmit(msg.image, msg.level, msg.ok, msg.width, msg.height),
+        session.probeSubmitById(msg.image, msg.level, msg.ok, msg.width, msg.height),
       );
       if (result.kind === "probe") {
         post({ type: "probe", uri: result.uri, headers: result.headers ?? {} });

--- a/test/pick-level.test.mjs
+++ b/test/pick-level.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { BROWSER_MAX_CANVAS_AREA, pickLevel } from "../src/main.ts";
+import { BROWSER_MAX_CANVAS_AREA } from "../packages/browser-runtime/src/limits.ts";
+import { pickEngineSelection } from "../packages/browser-runtime/src/engine-selection.ts";
 
 test("browser canvas bound matches legacy MAX_CANVAS_AREA", () => {
   assert.equal(BROWSER_MAX_CANVAS_AREA, 16384 * 16384);
@@ -10,35 +11,35 @@ test("picks the largest level that fits the browser canvas", () => {
   // World_Imagery-shaped WMTS levels, normalized ascending: the 2-gigapixel
   // deepest matrix must not win (planning it exhausts worker memory).
   const levels = [
-    { index: 0, imageSize: { x: 256, y: 256 } },
-    { index: 1, imageSize: { x: 8192, y: 8192 } },
-    { index: 2, imageSize: { x: 16384, y: 16384 } },
-    { index: 3, imageSize: { x: 32768, y: 32768 } },
-    { index: 4, imageSize: { x: 2147483648, y: 2140449280 } },
+    { id: "lvl:0", width: 256, height: 256 },
+    { id: "lvl:1", width: 8192, height: 8192 },
+    { id: "lvl:2", width: 16384, height: 16384 },
+    { id: "lvl:3", width: 32768, height: 32768 },
+    { id: "lvl:4", width: 2147483648, height: 2140449280 },
   ];
-  assert.deepEqual(pickLevel({ levels }), { index: 2 });
+  assert.deepEqual(pickEngineSelection({ images: [{ id: "img:0", readiness: "ready", levels }] }), { image: "img:0", level: "lvl:2" });
 });
 
 test("a level exactly at the bound still fits", () => {
   const levels = [
-    { index: 0, imageSize: { x: 8192, y: 8192 } },
-    { index: 1, imageSize: { x: 16384, y: 16384 } },
+    { id: "lvl:0", width: 8192, height: 8192 },
+    { id: "lvl:1", width: 16384, height: 16384 },
   ];
-  assert.deepEqual(pickLevel({ levels }), { index: 1 });
+  assert.deepEqual(pickEngineSelection({ images: [{ id: "img:0", readiness: "ready", levels }] }), { image: "img:0", level: "lvl:1" });
 });
 
 test("falls back to the smallest level when nothing fits", () => {
   const levels = [
-    { index: 0, imageSize: { x: 1073741824, y: 1070224896 } },
-    { index: 1, imageSize: { x: 2147483648, y: 2140449280 } },
+    { id: "lvl:0", width: 1073741824, height: 1070224896 },
+    { id: "lvl:1", width: 2147483648, height: 2140449280 },
   ];
   // Smallest, so the post-plan canvas check fails cheaply with desktop-app
   // guidance instead of planning the gigapixel level.
-  assert.deepEqual(pickLevel({ levels }), { index: 0 });
+  assert.deepEqual(pickEngineSelection({ images: [{ id: "img:0", readiness: "ready", levels }] }), { image: "img:0", level: "lvl:0" });
 });
 
-test("levels without a declared size keep the last one", () => {
-  const levels = [{ index: 0 }, { index: 1 }, { index: 2 }];
-  assert.deepEqual(pickLevel({ levels }), { index: 2 });
-  assert.deepEqual(pickLevel({ levels: [] }), { index: 0 });
+test("undeclared levels have no selectable geometry", () => {
+  const levels = [{ id: "lvl:0", width: 0, height: 0 }, { id: "lvl:1", width: 0, height: 0 }];
+  assert.equal(pickEngineSelection({ images: [{ id: "img:0", readiness: "ready", levels }] }), null);
+  assert.equal(pickEngineSelection({ images: [] }), null);
 });

--- a/testdata/scenarios/wasm/replay/expected/wasm.json
+++ b/testdata/scenarios/wasm/replay/expected/wasm.json
@@ -31,76 +31,76 @@
             {
               "height": 1,
               "id": "lvl:dzi:0:9",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 1
             },
             {
               "height": 2,
               "id": "lvl:dzi:0:8",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 2
             },
             {
               "height": 4,
               "id": "lvl:dzi:0:7",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 4
             },
             {
               "height": 8,
               "id": "lvl:dzi:0:6",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 8
             },
             {
               "height": 16,
               "id": "lvl:dzi:0:5",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 16
             },
             {
               "height": 32,
               "id": "lvl:dzi:0:4",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 32
             },
             {
               "height": 64,
               "id": "lvl:dzi:0:3",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 64
             },
             {
               "height": 128,
               "id": "lvl:dzi:0:2",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 128
             },
             {
               "height": 256,
               "id": "lvl:dzi:0:1",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 256
             },
             {
               "height": 512,
               "id": "lvl:dzi:0:0",
-              "tile_height": 256,
-              "tile_width": 256,
+              "tileHeight": 256,
+              "tileWidth": 256,
               "width": 512
             }
           ],
           "readiness": "ready",
-          "source_kind": "grid",
+          "sourceKind": "grid",
           "width": 512
         }
       ]


### PR DESCRIPTION
## Summary

- project WASM discovery catalogs through the protocol DTOs and plan with stable IDs
- reuse the browser runtime selector and plan gates in the website and extension modal
- cover the Eiffel krpano pyramid across the WASM and browser-selection boundaries

## Tests

- cargo xtask check
- cargo xtask test wasm
- cargo xtask test web --no-e2e\n- cargo xtask test extension (unit/build checks pass; packaged browser checks are blocked by the existing extension package-lock esbuild mismatch)