### PR TITLE
feat(ui): compact active job progress

### DIFF
--- a/apps/desktop/src/diagnostics.ts
+++ b/apps/desktop/src/diagnostics.ts
@@ -71,12 +71,26 @@ export function buildCopyDiagnostics(snapshot: DiagnosticsSnapshot): string {
 export function handleCopyDiagnostics(buildText: () => string): void {
   const text = buildText();
   const done = () => {
-    const btn = typeof document !== "undefined" ? document.getElementById("dz-btn-copy-diag") : null;
+    const btn = typeof document !== "undefined"
+      ? document.getElementById("dz-btn-copy-diagnostics") ?? document.getElementById("dz-btn-copy-diag")
+      : null;
     if (btn) {
-      btn.textContent = t("desktop.copy.copied");
+      const iconButton = btn.id === "dz-btn-copy-diagnostics";
+      if (iconButton) {
+        btn.setAttribute("title", t("desktop.copy.copied"));
+        btn.setAttribute("aria-label", t("desktop.copy.copied"));
+      } else {
+        btn.textContent = t("desktop.copy.copied");
+      }
       setTimeout(() => {
         try {
-          if (btn.isConnected) btn.textContent = t("desktop.copy.diagnostics");
+          if (!btn.isConnected) return;
+          if (iconButton) {
+            btn.setAttribute("title", t("desktop.copy.diagnostics"));
+            btn.setAttribute("aria-label", t("desktop.copy.diagnostics"));
+          } else {
+            btn.textContent = t("desktop.copy.diagnostics");
+          }
         } catch {
           // Button may be gone after re-render; ignore.
         }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1074,32 +1074,11 @@ function handleCancel(): void {
   if (isTerminalStatus(controller.getState().status)) return;
   const job = currentJobId;
   const invoke = tauriInvoke();
-  // Cancellation waits for the native worker's cleanup acknowledgement
-  // before reaching cancelled. The command only requests cancellation;
-  // the terminal state arrives through the cancelled event after any output
-  // path owned by the worker has been cleaned up.
-  pushLog("Cancelling… cleaning up…");
-  setStep(t("view.step.working"), t("desktop.step.cleanupDetail"));
-  pendingDecision = null;
-  catalogNotice = null;
-  if (invoke) {
-    if (!job) {
-      cancelPending = true;
-      pushLog("Waiting for the native job to start before cancelling…");
-      update();
-      return;
-    }
-    requestNativeCancellation(job, invoke);
-    return;
-  }
-  cancelPending = false;
-  controller.dispatch({ seq: nextSeq(), sessionId, kind: "cancel" });
-  pushLog("Cancelled by user; unfinished file removed");
-  stopHeartbeat();
-  // No native job exists to echo a cancelled event, so settle the queue entry
-  // here; otherwise it would stay active forever and block the queue.
-  settleActiveQueue("cancelled");
-  update();
+  // Stop is immediate in the UI. The native host still receives cancellation
+  // and performs cleanup, while its late events are retired below.
+  if (job && invoke) void invoke("cancel_job", { job }).catch(() => undefined);
+  handleReset();
+  if (job) retiredJobId = job;
 }
 
 // Destination recovery grants a replacement output. On grant, walks the controller into saving;
@@ -2029,10 +2008,9 @@ function ensureDesktopAuxPanel(): void {
     }
   }
   existing?.remove();
-  const showCopy = state.status !== "idle";
   const showPartialDone = state.status === "completed" && completedPartial;
   const showCancelledNote = state.status === "cancelled";
-  if (!decision && !showCopy && !showPartialDone && !showCancelledNote) {
+  if (!decision && !showPartialDone && !showCancelledNote) {
     if (prevKey !== null) {
       restoreFocus(recoveryReturnFocus);
       recoveryReturnFocus = null;
@@ -2185,28 +2163,6 @@ function ensureDesktopAuxPanel(): void {
 
   if (state.status !== "completed" && desktopQueue.entries.length > 1) appendDesktopQueuePanel(aux, doc);
 
-  if (showCopy) {
-    const copyRow = doc.createElement("div");
-    copyRow.className = "dz-actions-row";
-    const copyBtn = doc.createElement("button");
-    copyBtn.type = "button";
-    copyBtn.id = "dz-btn-copy-diag";
-    copyBtn.className = "dz-btn-secondary";
-    copyBtn.textContent = t("desktop.copy.diagnostics");
-    copyBtn.addEventListener("click", () => handleCopyDiagnostics(() => buildCopyDiagnostics(diagnosticsSnapshot())));
-    copyRow.appendChild(copyBtn);
-    if (state.status === "completed") {
-      const details = doc.createElement("details");
-      details.id = "dz-completed-details";
-      const summary = doc.createElement("summary");
-      summary.textContent = t("view.job.techDetails");
-      details.append(summary, copyRow);
-      aux.appendChild(details);
-    } else {
-      aux.appendChild(copyRow);
-    }
-  }
-
   card.appendChild(aux);
   if (decisionKey && decisionKey !== prevKey) {
     const primary = decisionBox?.querySelector("button.dz-btn-tactile") as HTMLElement | null;
@@ -2358,6 +2314,9 @@ function update() {
       },
       onCancel() {
         handleCancel();
+      },
+      onCopyDiagnostics(text: string) {
+        handleCopyDiagnostics(() => `${text}\n\n${buildCopyDiagnostics(diagnosticsSnapshot())}`);
       },
       onReset() {
         handleReset();

--- a/apps/desktop/tests/e2e.test.mjs
+++ b/apps/desktop/tests/e2e.test.mjs
@@ -99,13 +99,8 @@ await test("desktop production entry mounts and drives rendered controls", async
     click(window, document.querySelector("#dz-btn-cancel"), "job view renders Cancel");
     await eventually(() => calls.some((call) => call.command === "cancel_job"),
       "rendered Cancel did not invoke cancel_job");
-    emit("dezoomify://job-state", { job: "job:frontend", seq: 10,
-      kind: "cancelled", detail: "Cancelled" });
-    await eventually(() => app.controller.getState().status === "cancelled",
-      "cancel acknowledgement was not applied");
-    assert.equal(document.querySelector(".dz-card")?.dataset.viewPhase, "cancelled");
-
-    click(window, document.querySelector("#dz-btn-reset"), "cancelled view renders reset");
+    await eventually(() => app.controller.getState().status === "idle",
+      "cancel did not return directly to the initial view");
     assert.equal(document.querySelector(".dz-card")?.dataset.viewPhase, "idle");
     const startsBeforeHandoff = calls.filter((call) => call.command === "start_job").length;
     emit("dezoomify://deep-link-pending", {

--- a/apps/extension/src/job/index.ts
+++ b/apps/extension/src/job/index.ts
@@ -45,6 +45,12 @@ function boundEnvelope(type: string, extra: Record<string, unknown> = {}) { retu
 
 function root() { return document.getElementById("dz-job-app"); }
 
+function copyDiagnostics(text: string) {
+  if (text === "") return;
+  const operation = navigator.clipboard?.writeText?.(text);
+  void operation?.catch(() => undefined);
+}
+
 function render(status: string, ctx: ViewContext = {}) {
   const target = root();
   if (!target) return;
@@ -53,6 +59,7 @@ function render(status: string, ctx: ViewContext = {}) {
   renderView(target, { status, seq, sessionId: binding?.jobId ?? "job:pending", transport: "browser-session", imageCount: 0, ...(ctx.failure ? { error: ctx.failure } : {}) }, {
     onSubmitUrl: () => {},
     onCancel: closeJob,
+    onCopyDiagnostics: copyDiagnostics,
     onReset: () => {},
     onRetrySameUrl: () => {},
     onSave: () => {},

--- a/apps/extension/src/modal/modal.ts
+++ b/apps/extension/src/modal/modal.ts
@@ -146,6 +146,12 @@ function appRoot() {
   return document.getElementById("dz-modal-app");
 }
 
+function copyDiagnostics(text: string) {
+  if (text === "") return;
+  const operation = navigator.clipboard?.writeText?.(text);
+  void operation?.catch(() => undefined);
+}
+
 function throwIfCancelled() {
   if (modalState.cancelRequested) {
     throw Object.assign(new Error("cancelled by user"), { code: "cancelled" });
@@ -175,7 +181,9 @@ function render(status: string, ctx?: ModalContext) {
       onCancel: () => {
         modalState.cancelRequested = true;
         wakeCandidatesWaiter();
+        render("idle");
       },
+      onCopyDiagnostics: copyDiagnostics,
       onReset: () => {
         modalState.cancelRequested = false;
         void runDiscovery();

--- a/apps/extension/src/vendor/theme.css
+++ b/apps/extension/src/vendor/theme.css
@@ -914,7 +914,8 @@ abbr[title] {
   white-space: nowrap;
 }
 
-.dz-progress-percent {
+.dz-progress-percent,
+.dz-progress-count {
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   color: var(--dz-link-color);
@@ -930,13 +931,30 @@ abbr[title] {
   background: var(--dz-progress-track);
   border-radius: var(--dz-radius);
   overflow: hidden;
+  position: relative;
 }
 
-.dz-progress-bar {
+.dz-progress-done,
+.dz-progress-active {
+  position: absolute;
+  top: 0;
+  bottom: 0;
   height: 100%;
-  background: var(--dz-progress-bar);
   border-radius: var(--dz-radius);
+}
+
+.dz-progress-done {
+  left: 0;
+  background: var(--dz-progress-bar);
   transition: width 0.25s ease;
+}
+
+.dz-progress-active {
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(146, 117, 44, 0.88) 0 4px,
+    rgba(181, 146, 57, 0.88) 4px 8px
+  );
 }
 
 .dz-progress-controls {
@@ -954,7 +972,7 @@ abbr[title] {
 .dz-job-section {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.7rem;
   padding: 1.25rem 0 0.5rem;
   margin-top: 0.25rem;
   width: 100%;
@@ -974,11 +992,14 @@ abbr[title] {
 @media (prefers-reduced-motion: reduce) {
   .dz-fade-in { animation: none; }
   .dz-pulse { animation: none !important; }
-  .dz-indeterminate .dz-progress-bar { animation: none !important; }
+  .dz-indeterminate .dz-progress-done { animation: none !important; }
 }
 
-.dz-source-line {
+.dz-job-source-row {
   margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
   font-size: 0.85rem;
   color: var(--dz-text-muted);
   overflow: hidden;
@@ -988,11 +1009,22 @@ abbr[title] {
   min-width: 0;
 }
 
+.dz-job-source-label {
+  flex: 0 0 auto;
+}
+
 .dz-source-url {
   font-family: var(--dz-font-mono);
   font-size: 0.82rem;
   color: var(--dz-text-secondary);
   word-break: break-all;
+}
+
+.dz-job-time {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .dz-pulse {
@@ -1012,13 +1044,59 @@ abbr[title] {
   50% { opacity: 0.25; }
 }
 
-.dz-indeterminate .dz-progress-bar {
+.dz-indeterminate .dz-progress-done {
   animation: dzSlide 1.4s ease-in-out infinite alternate;
 }
 
 @keyframes dzSlide {
   from { margin-left: 0; }
   to { margin-left: calc(100% - 35%); }
+}
+
+.dz-progress-rail {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 0.45rem;
+}
+
+.dz-progress-buttons {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.dz-progress-control {
+  width: 32px;
+  min-width: 32px;
+  min-height: 0;
+  padding: 0;
+  border: 1px solid var(--dz-surface-border);
+  border-radius: var(--dz-radius);
+  background: var(--dz-btn-secondary-bg);
+  color: var(--dz-text-secondary);
+  cursor: pointer;
+  display: inline-grid;
+  place-items: center;
+}
+
+.dz-progress-control:hover {
+  background: var(--dz-btn-secondary-hover-bg);
+  color: var(--dz-text-primary);
+}
+
+.dz-progress-control:focus-visible {
+  outline: none;
+  box-shadow: var(--dz-focus-ring);
+}
+
+.dz-progress-control svg {
+  width: 15px;
+  height: 15px;
+  fill: currentColor;
+}
+
+.dz-stop-control svg rect {
+  rx: 1px;
 }
 
 .dz-tile-counts {
@@ -1299,6 +1377,42 @@ abbr[title] {
   background: transparent;
   margin-top: 1.25rem;
   padding-top: 0.25rem;
+  position: relative;
+}
+
+.dz-copy-diagnostics {
+  position: absolute;
+  top: 0.35rem;
+  right: 0;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--dz-radius);
+  background: transparent;
+  color: var(--dz-text-muted);
+  cursor: pointer;
+  display: inline-grid;
+  place-items: center;
+}
+
+.dz-copy-diagnostics:hover {
+  color: var(--dz-text-primary);
+  background: var(--dz-btn-secondary-bg);
+}
+
+.dz-copy-diagnostics:focus-visible {
+  outline: none;
+  box-shadow: var(--dz-focus-ring);
+}
+
+.dz-copy-diagnostics svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
 }
 
 .dz-summary {

--- a/apps/extension/src/vendor/theme.css
+++ b/apps/extension/src/vendor/theme.css
@@ -927,19 +927,27 @@ abbr[title] {
 
 .dz-progress-track {
   width: 100%;
-  height: 7px;
+  height: 1.5rem;
+  background: transparent;
+  position: relative;
+}
+
+.dz-progress-track::before {
+  content: "";
+  position: absolute;
+  top: calc(50% - 2px);
+  right: 0;
+  left: 0;
+  height: 4px;
   background: var(--dz-progress-track);
   border-radius: var(--dz-radius);
-  overflow: hidden;
-  position: relative;
 }
 
 .dz-progress-done,
 .dz-progress-active {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  height: 100%;
+  top: calc(50% - 2px);
+  height: 4px;
   border-radius: var(--dz-radius);
 }
 
@@ -1039,6 +1047,11 @@ abbr[title] {
   animation: dzPulse 1.6s ease-in-out infinite;
 }
 
+.dz-job-paused .dz-pulse {
+  animation: none;
+  opacity: 0.45;
+}
+
 @keyframes dzPulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.25; }
@@ -1055,33 +1068,34 @@ abbr[title] {
 
 .dz-progress-rail {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: stretch;
-  gap: 0.45rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .dz-progress-buttons {
   display: flex;
-  gap: 0.35rem;
+  align-items: center;
+  gap: 0.2rem;
+  height: 1.5rem;
 }
 
 .dz-progress-control {
-  width: 32px;
-  min-width: 32px;
-  min-height: 0;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
   padding: 0;
-  border: 1px solid var(--dz-surface-border);
-  border-radius: var(--dz-radius);
-  background: var(--dz-btn-secondary-bg);
-  color: var(--dz-text-secondary);
+  border: 0;
+  background: transparent;
+  color: var(--dz-text-muted);
   cursor: pointer;
   display: inline-grid;
   place-items: center;
 }
 
 .dz-progress-control:hover {
-  background: var(--dz-btn-secondary-hover-bg);
-  color: var(--dz-text-primary);
+  color: var(--dz-link-color);
 }
 
 .dz-progress-control:focus-visible {
@@ -1090,8 +1104,8 @@ abbr[title] {
 }
 
 .dz-progress-control svg {
-  width: 15px;
-  height: 15px;
+  width: 0.72rem;
+  height: 0.72rem;
   fill: currentColor;
 }
 

--- a/apps/extension/src/vendor/tile-draw.js
+++ b/apps/extension/src/vendor/tile-draw.js
@@ -11,7 +11,6 @@
 // decrypt/re-encode needs readable bytes. The host image constructor and
 // timers are injected so node tests drive the fallback with fakes. Keep
 // erasable-syntax-only for the browser `.js` mirrors.
-import { shortUrl } from "./tile-policy.js";
 
 /** Output placement of one decoded tile, shared by the website painter and
  * the engine-effect assembly executor: top-left corner plus the planned
@@ -21,8 +20,9 @@ import { shortUrl } from "./tile-policy.js";
  * Draw one decoded tile onto an output surface at its planned placement.
  * Trusts the plan for layout: the canvas stays seamless even when a tile
  * decodes at an unexpected size; the decoded bitmap is scaled to the
- * planned extent so no gap appears. `onMismatch` receives the diagnostic
- * line when the decoded and planned sizes disagree.
+ * planned extent so no gap appears. `onMismatch` receives a generic
+ * diagnostic when the decoded and planned sizes disagree; it never identifies
+ * an individual tile.
  */
 export function drawPlacedTile(
   ctx2d              ,
@@ -39,9 +39,7 @@ export function drawPlacedTile(
   const planW = geometry.w ?? fullW;
   const planH = geometry.h ?? fullH;
   if (planW !== fullW || planH !== fullH) {
-    onMismatch?.(
-      `tile size mismatch at ${geometry.x},${geometry.y}: plan ${planW}x${planH}, decoded ${fullW}x${fullH}`,
-    );
+    onMismatch?.("A tile size differed from the plan; it was scaled to keep the image seamless.");
   }
   if (planW > 0 && planH > 0 && fullW > 0 && fullH > 0) {
     ctx2d.drawImage(source, 0, 0, fullW, fullH, geometry.x, geometry.y, planW, planH);
@@ -76,7 +74,7 @@ export function loadTileImage(
         hooks.onRequestEnd(reqId, false);
         hooks.onUpdate();
       }
-      reject(new Error(`tile image unavailable without an image host: ${shortUrl(url)}`));
+      reject(new Error("tile image unavailable without an image host"));
       return;
     }
     const setTimer =
@@ -98,7 +96,7 @@ export function loadTileImage(
     img.addEventListener("load", () => done(true, img), { once: true });
     img.addEventListener(
       "error",
-      () => done(false, new Error(`tile image failed to load: ${shortUrl(url)}`)),
+      () => done(false, new Error("tile image failed to load")),
       { once: true },
     );
     timer = setTimer(() => {
@@ -107,7 +105,7 @@ export function loadTileImage(
       } catch {
         // Cancelling a hung load must never throw.
       }
-      done(false, new Error(`tile image timed out after ${ms / 1000}s: ${shortUrl(url)}`));
+      done(false, new Error(`tile image timed out after ${ms / 1000}s`));
     }, ms);
     // Don't tell the tile host the request comes from dezoomify (legacy parity).
     img.referrerPolicy = "no-referrer";
@@ -162,7 +160,7 @@ export function createTilePainter(deps              )              {
         ctx2d,
         source,
         { x: tile.x, y: tile.y, w: tile.w, h: tile.h },
-        (line) => deps.hooks.onLog(`${line} from ${shortUrl(tile.uri)}`),
+        (line) => deps.hooks.onLog(line),
       );
     };
     let readableFailure          = null;

--- a/apps/extension/src/vendor/tile-policy.js
+++ b/apps/extension/src/vendor/tile-policy.js
@@ -272,13 +272,13 @@ export function hostOf(url        )         {
 export function tileFailedError(
   lastOutcome        ,
   lastStatus                    ,
-  url        ,
+  _url        ,
 )                    {
   return failure(
     "TILE_FAILED",
     "Part of the image could not be saved. Try again in a moment.",
     true,
     undefined,
-    `tile fetch: ${lastOutcome} (HTTP ${lastStatus ?? "n/a"}) from ${shortUrl(url)} after ${TILE_MAX_RETRIES + 1} attempts`,
+    `tile fetch: ${lastOutcome} (HTTP ${lastStatus ?? "n/a"}) after ${TILE_MAX_RETRIES + 1} attempts`,
   );
 }

--- a/apps/extension/src/vendor/view.js
+++ b/apps/extension/src/vendor/view.js
@@ -836,14 +836,14 @@ function mountJobSection(
       <span class="dz-progress-count" id="dz-job-counts"></span>
     </div>
     <div class="dz-progress-rail">
-      <div class="dz-progress-track dz-indeterminate" id="dz-job-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-        <div class="dz-progress-done" id="dz-job-bar" style="width: 0%;"></div>
-        <div class="dz-progress-active" id="dz-job-active" style="width: 0%;"></div>
-      </div>
       <div class="dz-progress-buttons">
         <button type="button" class="dz-progress-control" id="dz-btn-pause" style="display: none;" aria-label="Pause" title="Pause"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="5" width="4" height="14"></rect><rect x="14" y="5" width="4" height="14"></rect></svg></button>
         <button type="button" class="dz-progress-control" id="dz-btn-resume" style="display: none;" aria-label="Resume" title="Resume"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8 5 11 7-11 7z"></path></svg></button>
         <button type="button" class="dz-progress-control dz-stop-control" id="dz-btn-cancel" aria-label="Stop and return to start" title="Stop and return to start"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="6" width="12" height="12"></rect></svg></button>
+      </div>
+      <div class="dz-progress-track dz-indeterminate" id="dz-job-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+        <div class="dz-progress-done" id="dz-job-bar" style="width: 0%;"></div>
+        <div class="dz-progress-active" id="dz-job-active" style="width: 0%;"></div>
       </div>
     </div>
     <details class="dz-details" id="dz-job-details">
@@ -903,13 +903,16 @@ function updateJobSection(
   const activePct = determinate ? (active / total) * 100 : 0;
   const retrying = Math.max(0, Math.min(ctx?.currentProgress?.retrying ?? 0, active));
   const paused = ctx?.paused === true || activity.paused === true;
+  if (paused) sec.classList.add("dz-job-paused");
+  else sec.classList.remove("dz-job-paused");
   const now = activity.now ?? Date.now();
   const startedAt = activity.startedAt ?? now;
-  const elapsedMs = Math.max(0, now - startedAt);
+  const timerNow = activity.pausedAt ?? now;
+  const elapsedMs = Math.max(0, timerNow - startedAt - (activity.pausedDurationMs ?? 0));
   const elapsed = formatElapsed(elapsedMs);
   const timeoutMs = activity.timeoutMs ?? 30000;
   const lastProgressAt = activity.lastProgressAt ?? startedAt;
-  const stalledMs = Math.max(0, now - lastProgressAt);
+  const stalledMs = Math.max(0, timerNow - lastProgressAt);
   const showStalled = stalledMs >= 10000 && state.status !== "saving";
   const step = paused
     ? "Paused"

--- a/apps/extension/src/vendor/view.js
+++ b/apps/extension/src/vendor/view.js
@@ -9,12 +9,9 @@ import { renderAppChoice } from "./controller.js";
 
 import { t } from "./i18n.js";
 import {
-  renderTransportLabel,
   renderSaveGuidance,
-  renderProgress,
   renderCompletion,
   formatElapsed,
-  formatRemaining,
   getDezoomifyLogoSvg,
 } from "./components.js";
 
@@ -509,6 +506,16 @@ function truncateMiddle(value        , max = 90)         {
   return `${s.slice(0, half)}…${s.slice(s.length - half)}`;
 }
 
+/** Display source context without query, fragment, or credentials. */
+function displaySourceUrl(value        )         {
+  try {
+    const url = new URL(value);
+    return truncateMiddle(`${url.host}${url.pathname}`, 90);
+  } catch {
+    return "source unavailable";
+  }
+}
+
 /** The website a request is waiting on, for plain-language messages. */
 function hostFromUrl(url                    )         {
   try {
@@ -816,43 +823,27 @@ function mountJobSection(
   (sec                                            )._callbacks = callbacks;
 
   sec.innerHTML = `
-    <p class="dz-source-line" id="dz-job-source-line" style="display: none;">
-      Working on <span class="dz-source-url" id="dz-job-source-url"></span>
-    </p>
+    <div class="dz-job-source-row" id="dz-job-source-line" style="display: none;">
+      <span class="dz-job-source-label">Source</span>
+      <span class="dz-source-url" id="dz-job-source-url"></span>
+      <span class="dz-job-time" id="dz-job-time"></span>
+    </div>
     <div class="dz-progress-header">
       <span class="dz-progress-status">
         <span class="dz-pulse" aria-hidden="true"></span>
         <span class="dz-progress-step-text" id="dz-job-step-text"></span>
       </span>
-      <span class="dz-progress-percent" id="dz-job-percent"></span>
+      <span class="dz-progress-count" id="dz-job-counts"></span>
     </div>
-    <div class="dz-progress-track dz-indeterminate" id="dz-job-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-      <div class="dz-progress-bar" id="dz-job-bar" style="width: 35%;"></div>
-    </div>
-    <p class="dz-tile-counts" id="dz-job-counts"></p>
-    <p class="dz-job-detail" id="dz-job-images" style="display: none;">
-      <span id="dz-job-images-text"></span>
-      <button type="button" class="dz-btn-link" id="dz-job-change">Change</button>
-    </p>
-    <p class="dz-job-detail" id="dz-job-change-hint" style="display: none;"></p>
-    <div class="dz-pending-box" id="dz-job-pending-box" style="display: none;">
-      <div class="dz-pending-line">
-        <span id="dz-job-pending-status"></span>
-        <span class="dz-pending-time" id="dz-job-pending-time"></span>
+    <div class="dz-progress-rail">
+      <div class="dz-progress-track dz-indeterminate" id="dz-job-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+        <div class="dz-progress-done" id="dz-job-bar" style="width: 0%;"></div>
+        <div class="dz-progress-active" id="dz-job-active" style="width: 0%;"></div>
       </div>
-      <div class="dz-remaining-track" aria-hidden="true">
-        <div class="dz-remaining-bar" id="dz-job-remaining-bar" style="width: 0%;"></div>
-      </div>
-    </div>
-    <p class="dz-reassure" id="dz-job-reassure" style="display: none;"></p>
-    <p class="dz-job-detail" id="dz-job-detail" style="display: none;"></p>
-    <div class="dz-progress-controls">
-      <span class="dz-transport-badge" id="dz-job-transport">Direct from your browser</span>
-      <div class="dz-job-actions">
-        <button type="button" class="dz-btn-secondary" id="dz-btn-share" style="display: none;">Copy shareable link</button>
-        <button type="button" class="dz-btn-secondary" id="dz-btn-pause" style="display: none;">Pause</button>
-        <button type="button" class="dz-btn-secondary" id="dz-btn-resume" style="display: none;">Resume</button>
-        <button type="button" class="dz-btn-secondary" id="dz-btn-cancel">Cancel</button>
+      <div class="dz-progress-buttons">
+        <button type="button" class="dz-progress-control" id="dz-btn-pause" style="display: none;" aria-label="Pause" title="Pause"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="5" width="4" height="14"></rect><rect x="14" y="5" width="4" height="14"></rect></svg></button>
+        <button type="button" class="dz-progress-control" id="dz-btn-resume" style="display: none;" aria-label="Resume" title="Resume"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8 5 11 7-11 7z"></path></svg></button>
+        <button type="button" class="dz-progress-control dz-stop-control" id="dz-btn-cancel" aria-label="Stop and return to start" title="Stop and return to start"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="6" width="12" height="12"></rect></svg></button>
       </div>
     </div>
     <details class="dz-details" id="dz-job-details">
@@ -860,6 +851,7 @@ function mountJobSection(
         <span>Technical details &amp; logs</span>
         <svg class="dz-summary-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
       </summary>
+      <button type="button" class="dz-copy-diagnostics" id="dz-btn-copy-diagnostics" style="display: none;" aria-label="Copy technical details" title="Copy technical details"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="10" height="11" rx="1"></rect><path d="M15 9V5H5v11h4"></path></svg></button>
       <div class="dz-diagnostics" id="dz-job-diagnostics"></div>
       <div class="dz-diagnostics dz-log" id="dz-job-log" style="display: none;"></div>
     </details>
@@ -877,13 +869,9 @@ function mountJobSection(
     const cb = (sec                                            )._callbacks;
     cb?.onResume?.();
   });
-  sec.querySelector("#dz-btn-share")?.addEventListener("click", () => {
-    const cb = (sec                                            )._callbacks;
-    cb?.onCopyShareLink?.();
-  });
-  sec.querySelector("#dz-job-change")?.addEventListener("click", () => {
-    const hint = sec.querySelector             ("#dz-job-change-hint");
-    if (hint) hint.style.display = hint.style.display === "none" ? "" : "none";
+  sec.querySelector("#dz-btn-copy-diagnostics")?.addEventListener("click", () => {
+    const stored = sec                                                                   ;
+    stored._callbacks?.onCopyDiagnostics?.(stored._diagnostics ?? "");
   });
 
   parent.appendChild(sec);
@@ -908,26 +896,37 @@ function updateJobSection(
   const current = ctx?.currentProgress?.current ?? 0;
   const total = ctx?.currentProgress?.total ?? 0;
   const determinate = total > 0;
-  const pct = determinate ? Math.max(0, Math.min(100, Math.round((current / total) * 100))) : 0;
-  const transport = state.transport ? renderTransportLabel(state.transport) : "Direct from your browser";
+  const donePct = determinate ? Math.max(0, Math.min(100, (current / total) * 100)) : 0;
+  const active = determinate
+    ? Math.max(0, Math.min(ctx?.currentProgress?.active ?? 0, Math.max(0, total - current)))
+    : 0;
+  const activePct = determinate ? (active / total) * 100 : 0;
+  const retrying = Math.max(0, Math.min(ctx?.currentProgress?.retrying ?? 0, active));
   const paused = ctx?.paused === true || activity.paused === true;
-  const step = paused
-    ? "Paused. No new pieces are being fetched."
-    : activity.stepLabel || ctx?.currentProgress?.message || defaultStepFor(state.status);
   const now = activity.now ?? Date.now();
   const startedAt = activity.startedAt ?? now;
   const elapsedMs = Math.max(0, now - startedAt);
   const elapsed = formatElapsed(elapsedMs);
-  const pending = activity.pendingRequests ?? 0;
-  const completed = activity.completedRequests ?? 0;
-  const failed = activity.failedRequests ?? 0;
-  const longestPending = activity.longestPendingMs ?? 0;
   const timeoutMs = activity.timeoutMs ?? 30000;
   const lastProgressAt = activity.lastProgressAt ?? startedAt;
   const stalledMs = Math.max(0, now - lastProgressAt);
-  const showPending = pending > 0 && (elapsedMs >= 2000 || longestPending >= 2000);
   const showStalled = stalledMs >= 10000 && state.status !== "saving";
-  const sourceUrl = activity.url ? truncateMiddle(activity.url, 90) : "";
+  const step = paused
+    ? "Paused"
+    : retrying > 0
+      ? `Retrying ${retrying} tile${retrying === 1 ? "" : "s"}…`
+      : showStalled
+        ? `Waiting for ${hostFromUrl(activity.url)}…`
+        : activity.stepLabel || ctx?.currentProgress?.message || defaultStepFor(state.status);
+  const sourceUrl = activity.url ? displaySourceUrl(activity.url) : "";
+  const estimatedTotalMs = ctx?.currentProgress?.estimatedTotalMs ?? (
+    determinate && current >= 2 && elapsedMs >= 2000
+      ? Math.round((elapsedMs / current) * total)
+      : undefined
+  );
+  const timeText = elapsed
+    ? `${elapsed}${typeof estimatedTotalMs === "number" && estimatedTotalMs > elapsedMs ? ` / ~${formatElapsed(estimatedTotalMs)}` : ""}`
+    : "";
 
   // 1. Source Line
   const sourceLine = sec.querySelector             ("#dz-job-source-line");
@@ -935,7 +934,7 @@ function updateJobSection(
   if (sourceLine && sourceUrlEl) {
     if (sourceUrl) {
       sourceLine.style.display = "";
-      sourceLine.title = activity.url ?? "";
+      sourceLine.title = sourceUrl;
       if (sourceUrlEl.textContent !== sourceUrl) {
         sourceUrlEl.textContent = sourceUrl;
       }
@@ -943,147 +942,48 @@ function updateJobSection(
       sourceLine.style.display = "none";
     }
   }
+  const timeEl = sec.querySelector             ("#dz-job-time");
+  if (timeEl && timeEl.textContent !== timeText) timeEl.textContent = timeText;
 
-  // 2. Step Label & Percent/Elapsed
+  // 2. Phase and exact tile summary.
   const stepEl = sec.querySelector             ("#dz-job-step-text");
   if (stepEl && stepEl.textContent !== step) {
     stepEl.textContent = step;
   }
 
-  const percentEl = sec.querySelector             ("#dz-job-percent");
-  if (percentEl) {
-    const percentText = determinate ? `${pct}%` : (elapsed || "");
-    if (percentEl.textContent !== percentText) {
-      percentEl.textContent = percentText;
-    }
-  }
+  const countsEl = sec.querySelector             ("#dz-job-counts");
+  const countsText = determinate
+    ? `${current} done${active > 0 ? ` + ${active} in progress` : ""} / ${total}`
+    : "";
+  if (countsEl && countsEl.textContent !== countsText) countsEl.textContent = countsText;
 
   // 3. Track and Bar
   const track = sec.querySelector             ("#dz-job-track");
   const bar = sec.querySelector             ("#dz-job-bar");
   if (track && bar) {
-    track.setAttribute("aria-valuenow", String(pct));
+    track.setAttribute("aria-valuenow", String(current));
+    track.setAttribute("aria-valuemax", String(total || 100));
     track.setAttribute("aria-label", step);
+    track.setAttribute(
+      "aria-valuetext",
+      determinate
+        ? `${current} done, ${active} in progress, ${Math.max(0, total - current - active)} remaining`
+        : step,
+    );
     if (determinate) {
       track.classList.remove("dz-indeterminate");
-      bar.style.width = `${pct}%`;
+      bar.style.width = `${donePct}%`;
     } else {
       track.classList.add("dz-indeterminate");
       bar.style.width = "35%";
     }
-  }
-
-  // 4. Counts
-  const countsEl = sec.querySelector             ("#dz-job-counts");
-  if (countsEl) {
-    const countsText = determinate
-      ? `${current} of ${total} tiles${elapsed ? ` · ${elapsed} elapsed` : ""}`
-      : elapsed
-        ? `${elapsed} elapsed`
-        : "";
-    if (countsEl.textContent !== countsText) {
-      countsEl.textContent = countsText;
+    const activeBar = sec.querySelector             ("#dz-job-active");
+    if (activeBar) {
+      activeBar.style.left = determinate ? `${donePct}%` : "0%";
+      activeBar.style.width = determinate ? `${activePct}%` : "0%";
     }
   }
-
-  // 4b. Catalog auto-choice notice (todo 4.3): honest step without a picker.
-  // Uses existing controller imageCount, never a new protocol event. WxH and
-  // tile counts come from local ViewContext.imageChoice when known.
-  const imagesEl = sec.querySelector             ("#dz-job-images");
-  const imagesText = sec.querySelector             ("#dz-job-images-text");
-  const changeHint = sec.querySelector             ("#dz-job-change-hint");
-  const choiceCount = state.imageCount ?? 0;
-  if (imagesEl && imagesText) {
-    if (choiceCount > 0) {
-      const choiceWidth = ctx?.imageChoice?.width ?? ctx?.completedInfo?.width ?? 0;
-      const choiceHeight = ctx?.imageChoice?.height ?? ctx?.completedInfo?.height ?? 0;
-      const choiceTiles = ctx?.imageChoice?.tiles ?? (determinate ? total : 0);
-      const noun = choiceCount === 1 ? "1 image" : `${choiceCount} images`;
-      let suffix = ".";
-      if (choiceWidth > 0 && choiceHeight > 0 && choiceTiles > 0) {
-        suffix = ` (${choiceWidth}×${choiceHeight}, ${choiceTiles} tiles).`;
-      } else if (choiceWidth > 0 && choiceHeight > 0) {
-        suffix = ` (${choiceWidth}×${choiceHeight}).`;
-      } else if (choiceTiles > 0) {
-        suffix = ` (${choiceTiles} tiles).`;
-      }
-      const notice = `Found ${noun}, saving largest that fits${suffix}`;
-      if (imagesText.textContent !== notice) imagesText.textContent = notice;
-      imagesEl.style.display = "";
-      if (changeHint) {
-        const hint = "The website saves the largest image automatically. To choose a different image, use the desktop app.";
-        if (changeHint.textContent !== hint) changeHint.textContent = hint;
-      }
-    } else {
-      imagesEl.style.display = "none";
-      if (changeHint) changeHint.style.display = "none";
-    }
-  }
-
-  // 5. Pending section
-  const pendingBox = sec.querySelector             ("#dz-job-pending-box");
-  const pendingStatus = sec.querySelector             ("#dz-job-pending-status");
-  const pendingTime = sec.querySelector             ("#dz-job-pending-time");
-  const remainingBar = sec.querySelector             ("#dz-job-remaining-bar");
-  if (pendingBox) {
-    if (showPending) {
-      pendingBox.style.display = "";
-      if (pendingStatus) {
-        const text = `${pending} request${pending === 1 ? "" : "s"} in flight${completed > 0 ? ` · ${completed} done` : ""}${failed > 0 ? ` · ${failed} failed, retrying` : ""}`;
-        if (pendingStatus.textContent !== text) {
-          pendingStatus.textContent = text;
-        }
-      }
-      if (pendingTime) {
-        const timeText = `${formatElapsed(longestPending)} waiting · ${formatRemaining(longestPending, timeoutMs)}`;
-        if (pendingTime.textContent !== timeText) {
-          pendingTime.textContent = timeText;
-        }
-      }
-      if (remainingBar) {
-        const remainingPct = Math.max(0, Math.min(100, Math.round((longestPending / timeoutMs) * 100)));
-        remainingBar.style.width = `${remainingPct}%`;
-      }
-    } else {
-      pendingBox.style.display = "none";
-    }
-  }
-
-  // 6. Stalled Reassurance
-  const reassureEl = sec.querySelector             ("#dz-job-reassure");
-  if (reassureEl) {
-    reassureEl.style.display = showStalled ? "" : "none";
-    const reassureText = `Still working, ${hostFromUrl(activity.url)} is slow to answer. You can wait, or cancel and try again later.`;
-    if (reassureEl.textContent !== reassureText) {
-      reassureEl.textContent = reassureText;
-    }
-  }
-
-  // 7. Detail
-  const detailEl = sec.querySelector             ("#dz-job-detail");
-  if (detailEl) {
-    if (activity.detail) {
-      detailEl.style.display = "";
-      if (detailEl.textContent !== activity.detail) {
-        detailEl.textContent = activity.detail;
-      }
-    } else {
-      detailEl.style.display = "none";
-    }
-  }
-
-  // 8. Transport badge & Action buttons
-  const transportEl = sec.querySelector             ("#dz-job-transport");
-  if (transportEl && transportEl.textContent !== transport) {
-    transportEl.textContent = transport;
-  }
-
-  const shareBtn = sec.querySelector             ("#dz-btn-share");
-  if (shareBtn) {
-    shareBtn.style.display = callbacks.onCopyShareLink ? "" : "none";
-  }
-
-  // Pause v1 (todo 5.7): suspend-acquisition controls. Pause shows while
+  // 4. Pause v1: acquisition controls belong to the rail itself. Pause shows while
   // running with a pause handler; Resume shows while paused with a resume
   // handler. Hosts own the effect; the view only renders the overlay.
   const pauseBtn = sec.querySelector             ("#dz-btn-pause");
@@ -1098,13 +998,15 @@ function updateJobSection(
   }
 
   // 9. Diagnostics & Logs (preserved in-place, keeping details open state intact)
+  const diagText = diagnosticsText(state, ctx, elapsedMs, timeoutMs);
   const diagEl = sec.querySelector             ("#dz-job-diagnostics");
   if (diagEl) {
-    const diagText = diagnosticsText(state, ctx, elapsedMs, timeoutMs);
     if (diagEl.textContent !== diagText) {
       diagEl.textContent = diagText;
     }
   }
+  const copyBtn = sec.querySelector             ("#dz-btn-copy-diagnostics");
+  if (copyBtn) copyBtn.style.display = callbacks.onCopyDiagnostics ? "" : "none";
 
   const logEl = sec.querySelector             ("#dz-job-log");
   if (logEl) {
@@ -1118,6 +1020,8 @@ function updateJobSection(
       logEl.style.display = "none";
     }
   }
+  const copiedLog = activity.log && activity.log.length > 0 ? `\n\nEvents\n${activity.log.join("\n")}` : "";
+  (sec                                        )._diagnostics = `${diagText}${activity.diagnostics ? `\n\n${activity.diagnostics}` : ""}${copiedLog}`;
 }
 
 function diagnosticsText(
@@ -1136,7 +1040,9 @@ function diagnosticsText(
     `Requests: ${a.pendingRequests ?? 0} pending, ${a.completedRequests ?? 0} done, ${a.failedRequests ?? 0} failed`,
   ];
   if (p) lines.push(`Tiles: ${p.current} of ${p.total}`);
-  if (a.url) lines.push(`Source: ${a.url}`);
+  if (p?.active !== undefined) lines.push(`Tiles active: ${p.active}`);
+  if (p?.retrying !== undefined) lines.push(`Tiles retrying: ${p.retrying}`);
+  if (a.url) lines.push(`Source: ${displaySourceUrl(a.url)}`);
   return lines.join("\n");
 }
 
@@ -1321,7 +1227,6 @@ function mountCompletedSection(
         </svg>
         Save image
       </button>` : ""}
-      ${callbacks.onCopyShareLink ? `<button type="button" class="dz-btn-secondary" id="dz-btn-share">Copy shareable link</button>` : ""}
       <button type="button" class="dz-btn-secondary" id="dz-btn-another">Dezoomify another image</button>
     </div>
   `;
@@ -1329,7 +1234,6 @@ function mountCompletedSection(
   section.querySelector("#dz-btn-save")?.addEventListener("click", () => callbacks.onSave?.());
   section.querySelector("#dz-btn-open")?.addEventListener("click", () => callbacks.onOpenOutput?.());
   section.querySelector("#dz-btn-reveal")?.addEventListener("click", () => callbacks.onRevealOutput?.());
-  section.querySelector("#dz-btn-share")?.addEventListener("click", () => callbacks.onCopyShareLink?.());
   section.querySelector("#dz-btn-another")?.addEventListener("click", () => callbacks.onReset());
   parent.appendChild(section);
 }

--- a/apps/extension/tests/unit/shared-ui-parity.test.mjs
+++ b/apps/extension/tests/unit/shared-ui-parity.test.mjs
@@ -281,13 +281,12 @@ test("extension job card carries the website geometry", () => {
   const job = card.querySelector(".dz-job-section");
   assert.ok(job, "job section mounted");
   assert.equal(card.querySelector("#dz-job-step-text").textContent, "Saving image tiles…");
-  assert.equal(card.querySelector("#dz-job-transport").textContent, "Browser session");
-  assert.equal(card.querySelector("#dz-job-percent").textContent, "25%");
+  assert.equal(card.querySelector("#dz-job-counts").textContent, "1 done / 4");
   assert.equal(card.querySelector("#dz-job-bar").style.width, "25%");
-  assert.equal(card.querySelector("#dz-job-track").getAttribute("aria-valuenow"), "25");
+  assert.equal(card.querySelector("#dz-job-track").getAttribute("aria-valuenow"), "1");
   const cancel = card.querySelector("#dz-btn-cancel");
   assert.ok(cancel, "cancel action mounted");
-  assert.ok(cancel.classList.contains("dz-btn-secondary"), "cancel uses the shared secondary geometry");
+  assert.ok(cancel.classList.contains("dz-progress-control"), "cancel is integrated with the shared progress rail");
 });
 
 test("extension completion reads saved with the file name, no second save click", () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,8 @@ policy: the web integration tries a direct browser fetch first, with browser
 credentials omitted, and may automatically use the metadata CORS proxy only
 after a classified CORS or network failure, or a direct fetch that does not
 complete within the 1500 ms metadata window, for an eligible public,
-non-credential metadata request (never tiles). The active transport is always visible. No cookies,
+non-credential metadata request (never tiles). The active transport is retained
+in the job's technical details and copied diagnostics. No cookies,
 `Authorization`, browser credentials, or user-supplied credential headers are
 sent to or by the proxy. The extension never uses the metadata CORS proxy;
 extension-to-native cookie handoff is separately consent-gated. The extension

--- a/packages/browser-runtime/src/tile-draw.ts
+++ b/packages/browser-runtime/src/tile-draw.ts
@@ -7,7 +7,6 @@
 // decrypt/re-encode needs readable bytes. The host image constructor and
 // timers are injected so node tests drive the fallback with fakes. Keep
 // erasable-syntax-only for the browser `.js` mirrors.
-import { shortUrl } from "./tile-policy.ts";
 import type { PlanTile } from "./session.ts";
 import type { TileBitmap } from "./tile-decode.ts";
 
@@ -73,8 +72,9 @@ export interface PlacedTileGeometry {
  * Draw one decoded tile onto an output surface at its planned placement.
  * Trusts the plan for layout: the canvas stays seamless even when a tile
  * decodes at an unexpected size; the decoded bitmap is scaled to the
- * planned extent so no gap appears. `onMismatch` receives the diagnostic
- * line when the decoded and planned sizes disagree.
+ * planned extent so no gap appears. `onMismatch` receives a generic
+ * diagnostic when the decoded and planned sizes disagree; it never identifies
+ * an individual tile.
  */
 export function drawPlacedTile(
   ctx2d: Canvas2DLike,
@@ -91,9 +91,7 @@ export function drawPlacedTile(
   const planW = geometry.w ?? fullW;
   const planH = geometry.h ?? fullH;
   if (planW !== fullW || planH !== fullH) {
-    onMismatch?.(
-      `tile size mismatch at ${geometry.x},${geometry.y}: plan ${planW}x${planH}, decoded ${fullW}x${fullH}`,
-    );
+    onMismatch?.("A tile size differed from the plan; it was scaled to keep the image seamless.");
   }
   if (planW > 0 && planH > 0 && fullW > 0 && fullH > 0) {
     ctx2d.drawImage(source, 0, 0, fullW, fullH, geometry.x, geometry.y, planW, planH);
@@ -132,7 +130,7 @@ export function loadTileImage(
         hooks.onRequestEnd(reqId, false);
         hooks.onUpdate();
       }
-      reject(new Error(`tile image unavailable without an image host: ${shortUrl(url)}`));
+      reject(new Error("tile image unavailable without an image host"));
       return;
     }
     const setTimer =
@@ -154,7 +152,7 @@ export function loadTileImage(
     img.addEventListener("load", () => done(true, img), { once: true });
     img.addEventListener(
       "error",
-      () => done(false, new Error(`tile image failed to load: ${shortUrl(url)}`)),
+      () => done(false, new Error("tile image failed to load")),
       { once: true },
     );
     timer = setTimer(() => {
@@ -163,7 +161,7 @@ export function loadTileImage(
       } catch {
         // Cancelling a hung load must never throw.
       }
-      done(false, new Error(`tile image timed out after ${ms / 1000}s: ${shortUrl(url)}`));
+      done(false, new Error(`tile image timed out after ${ms / 1000}s`));
     }, ms);
     // Don't tell the tile host the request comes from dezoomify (legacy parity).
     img.referrerPolicy = "no-referrer";
@@ -226,7 +224,7 @@ export function createTilePainter(deps: TileDrawDeps): TilePainter {
         ctx2d,
         source,
         { x: tile.x, y: tile.y, w: tile.w, h: tile.h },
-        (line) => deps.hooks.onLog(`${line} from ${shortUrl(tile.uri)}`),
+        (line) => deps.hooks.onLog(line),
       );
     };
     let readableFailure: unknown = null;

--- a/packages/browser-runtime/src/tile-policy.ts
+++ b/packages/browser-runtime/src/tile-policy.ts
@@ -289,14 +289,13 @@ export function hostOf(url: string): string {
 export function tileFailedError(
   lastOutcome: string,
   lastStatus: number | undefined,
-  url: string,
+  _url: string,
 ): StructuredFailure {
   return failure(
     "TILE_FAILED",
     "Part of the image could not be saved. Try again in a moment.",
     true,
     undefined,
-    `tile fetch: ${lastOutcome} (HTTP ${lastStatus ?? "n/a"}) from ${shortUrl(url)} after ${TILE_MAX_RETRIES + 1} attempts`,
+    `tile fetch: ${lastOutcome} (HTTP ${lastStatus ?? "n/a"}) after ${TILE_MAX_RETRIES + 1} attempts`,
   );
 }
-

--- a/packages/browser-runtime/src/web-fetch.ts
+++ b/packages/browser-runtime/src/web-fetch.ts
@@ -258,7 +258,7 @@ export interface WebFetchDeps {
 }
 
 export interface WebFetcher {
-  fetchDirect(url: string, headers?: Record<string, string>, signal?: AbortSignal, ms?: number): Promise<DirectOutcome>;
+  fetchDirect(url: string, headers?: Record<string, string>, signal?: AbortSignal, ms?: number, logTimeout?: boolean): Promise<DirectOutcome>;
   fetchViaProxy(targetUrl: string, signal?: AbortSignal): Promise<{
     ok: boolean;
     status: number;
@@ -427,6 +427,7 @@ export function createWebFetcher(deps: WebFetchDeps): WebFetcher {
     headers?: Record<string, string>,
     signal?: AbortSignal,
     ms: number = requestMs,
+    logTimeout: boolean = true,
   ): Promise<DirectOutcome> {
     if (!fetchImpl) return { outcome: "network-error" };
     const reqId = hooks.onRequestStart("direct");
@@ -459,7 +460,7 @@ export function createWebFetcher(deps: WebFetchDeps): WebFetcher {
       if (signal?.aborted) return { outcome: "cancelled" };
       const name = (e as { name?: string })?.name;
       if (name === "TimeoutError" || (combined.timedOut && combined.timedOut())) {
-        hooks.onLog(`Direct fetch did not complete within ${ms} ms: ${shortUrl(url)}`);
+        if (logTimeout) hooks.onLog(`Direct metadata fetch did not complete within ${ms} ms: ${shortUrl(url)}`);
         return { outcome: "network-error" };
       }
       return { outcome: "network-error" };
@@ -650,7 +651,7 @@ export function createWebFetcher(deps: WebFetchDeps): WebFetcher {
           // Throttle waits must never fail a tile.
         }
       }
-      const direct = await fetchDirect(url, headers);
+      const direct = await fetchDirect(url, headers, undefined, requestMs, false);
       if (direct.outcome === "readable" && direct.bytes) {
         return { bytes: direct.bytes };
       }

--- a/packages/browser-runtime/test/assembly.test.mjs
+++ b/packages/browser-runtime/test/assembly.test.mjs
@@ -100,7 +100,7 @@ test("a decoded size mismatch scales to the planned extent and logs", async () =
   await assembly.finalizeEncoder();
   assert.deepEqual(ctx2d.draws[0], { source: ctx2d.draws[0].source, sx: 0, sy: 0, sw: 10, sh: 10, dx: 0, dy: 0, dw: 16, dh: 16 });
   assert.equal(events.log.length, 1);
-  assert.match(events.log[0], /tile size mismatch at 0,0/);
+  assert.equal(events.log[0], "A tile size differed from the plan; it was scaled to keep the image seamless.");
 });
 
 test("undeclared canvas derives the output size from placements", async () => {

--- a/packages/browser-runtime/test/tile-draw.test.mjs
+++ b/packages/browser-runtime/test/tile-draw.test.mjs
@@ -54,7 +54,8 @@ test("drawTile trusts the plan and logs size mismatches", async () => {
   await painter.drawTile(ctx, { uri: "https://a.test/1.png", headers: {}, x: 256, y: 0, w: 256, h: 256, processing: "none" });
   assert.equal(ctx.drawn.length, 1);
   assert.equal(ctx.drawn[0].dw, 256);
-  assert.ok(log.some((line) => line.includes("tile size mismatch")), "mismatch logged");
+  assert.ok(log.some((line) => line.includes("A tile size differed from the plan")), "mismatch logged without identifying a tile");
+  assert.ok(log.every((line) => !line.includes("a.test") && !line.includes("256,0")), "mismatch log has no tile URL or coordinates");
 });
 
 test("drawTile falls back to ordinary display for unprocessed tiles", async () => {

--- a/packages/shared-ui/src/styles/theme.css
+++ b/packages/shared-ui/src/styles/theme.css
@@ -914,7 +914,8 @@ abbr[title] {
   white-space: nowrap;
 }
 
-.dz-progress-percent {
+.dz-progress-percent,
+.dz-progress-count {
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   color: var(--dz-link-color);
@@ -930,13 +931,30 @@ abbr[title] {
   background: var(--dz-progress-track);
   border-radius: var(--dz-radius);
   overflow: hidden;
+  position: relative;
 }
 
-.dz-progress-bar {
+.dz-progress-done,
+.dz-progress-active {
+  position: absolute;
+  top: 0;
+  bottom: 0;
   height: 100%;
-  background: var(--dz-progress-bar);
   border-radius: var(--dz-radius);
+}
+
+.dz-progress-done {
+  left: 0;
+  background: var(--dz-progress-bar);
   transition: width 0.25s ease;
+}
+
+.dz-progress-active {
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(146, 117, 44, 0.88) 0 4px,
+    rgba(181, 146, 57, 0.88) 4px 8px
+  );
 }
 
 .dz-progress-controls {
@@ -954,7 +972,7 @@ abbr[title] {
 .dz-job-section {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.7rem;
   padding: 1.25rem 0 0.5rem;
   margin-top: 0.25rem;
   width: 100%;
@@ -974,11 +992,14 @@ abbr[title] {
 @media (prefers-reduced-motion: reduce) {
   .dz-fade-in { animation: none; }
   .dz-pulse { animation: none !important; }
-  .dz-indeterminate .dz-progress-bar { animation: none !important; }
+  .dz-indeterminate .dz-progress-done { animation: none !important; }
 }
 
-.dz-source-line {
+.dz-job-source-row {
   margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
   font-size: 0.85rem;
   color: var(--dz-text-muted);
   overflow: hidden;
@@ -988,11 +1009,22 @@ abbr[title] {
   min-width: 0;
 }
 
+.dz-job-source-label {
+  flex: 0 0 auto;
+}
+
 .dz-source-url {
   font-family: var(--dz-font-mono);
   font-size: 0.82rem;
   color: var(--dz-text-secondary);
   word-break: break-all;
+}
+
+.dz-job-time {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .dz-pulse {
@@ -1012,13 +1044,59 @@ abbr[title] {
   50% { opacity: 0.25; }
 }
 
-.dz-indeterminate .dz-progress-bar {
+.dz-indeterminate .dz-progress-done {
   animation: dzSlide 1.4s ease-in-out infinite alternate;
 }
 
 @keyframes dzSlide {
   from { margin-left: 0; }
   to { margin-left: calc(100% - 35%); }
+}
+
+.dz-progress-rail {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 0.45rem;
+}
+
+.dz-progress-buttons {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.dz-progress-control {
+  width: 32px;
+  min-width: 32px;
+  min-height: 0;
+  padding: 0;
+  border: 1px solid var(--dz-surface-border);
+  border-radius: var(--dz-radius);
+  background: var(--dz-btn-secondary-bg);
+  color: var(--dz-text-secondary);
+  cursor: pointer;
+  display: inline-grid;
+  place-items: center;
+}
+
+.dz-progress-control:hover {
+  background: var(--dz-btn-secondary-hover-bg);
+  color: var(--dz-text-primary);
+}
+
+.dz-progress-control:focus-visible {
+  outline: none;
+  box-shadow: var(--dz-focus-ring);
+}
+
+.dz-progress-control svg {
+  width: 15px;
+  height: 15px;
+  fill: currentColor;
+}
+
+.dz-stop-control svg rect {
+  rx: 1px;
 }
 
 .dz-tile-counts {
@@ -1299,6 +1377,42 @@ abbr[title] {
   background: transparent;
   margin-top: 1.25rem;
   padding-top: 0.25rem;
+  position: relative;
+}
+
+.dz-copy-diagnostics {
+  position: absolute;
+  top: 0.35rem;
+  right: 0;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--dz-radius);
+  background: transparent;
+  color: var(--dz-text-muted);
+  cursor: pointer;
+  display: inline-grid;
+  place-items: center;
+}
+
+.dz-copy-diagnostics:hover {
+  color: var(--dz-text-primary);
+  background: var(--dz-btn-secondary-bg);
+}
+
+.dz-copy-diagnostics:focus-visible {
+  outline: none;
+  box-shadow: var(--dz-focus-ring);
+}
+
+.dz-copy-diagnostics svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linejoin: round;
 }
 
 .dz-summary {

--- a/packages/shared-ui/src/styles/theme.css
+++ b/packages/shared-ui/src/styles/theme.css
@@ -927,19 +927,27 @@ abbr[title] {
 
 .dz-progress-track {
   width: 100%;
-  height: 7px;
+  height: 1.5rem;
+  background: transparent;
+  position: relative;
+}
+
+.dz-progress-track::before {
+  content: "";
+  position: absolute;
+  top: calc(50% - 2px);
+  right: 0;
+  left: 0;
+  height: 4px;
   background: var(--dz-progress-track);
   border-radius: var(--dz-radius);
-  overflow: hidden;
-  position: relative;
 }
 
 .dz-progress-done,
 .dz-progress-active {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  height: 100%;
+  top: calc(50% - 2px);
+  height: 4px;
   border-radius: var(--dz-radius);
 }
 
@@ -1039,6 +1047,11 @@ abbr[title] {
   animation: dzPulse 1.6s ease-in-out infinite;
 }
 
+.dz-job-paused .dz-pulse {
+  animation: none;
+  opacity: 0.45;
+}
+
 @keyframes dzPulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.25; }
@@ -1055,33 +1068,34 @@ abbr[title] {
 
 .dz-progress-rail {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: stretch;
-  gap: 0.45rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .dz-progress-buttons {
   display: flex;
-  gap: 0.35rem;
+  align-items: center;
+  gap: 0.2rem;
+  height: 1.5rem;
 }
 
 .dz-progress-control {
-  width: 32px;
-  min-width: 32px;
-  min-height: 0;
+  width: 1.25rem;
+  min-width: 1.25rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
   padding: 0;
-  border: 1px solid var(--dz-surface-border);
-  border-radius: var(--dz-radius);
-  background: var(--dz-btn-secondary-bg);
-  color: var(--dz-text-secondary);
+  border: 0;
+  background: transparent;
+  color: var(--dz-text-muted);
   cursor: pointer;
   display: inline-grid;
   place-items: center;
 }
 
 .dz-progress-control:hover {
-  background: var(--dz-btn-secondary-hover-bg);
-  color: var(--dz-text-primary);
+  color: var(--dz-link-color);
 }
 
 .dz-progress-control:focus-visible {
@@ -1090,8 +1104,8 @@ abbr[title] {
 }
 
 .dz-progress-control svg {
-  width: 15px;
-  height: 15px;
+  width: 0.72rem;
+  height: 0.72rem;
   fill: currentColor;
 }
 

--- a/packages/shared-ui/src/view.ts
+++ b/packages/shared-ui/src/view.ts
@@ -6,12 +6,9 @@ import { renderAppChoice } from "./controller.ts";
 import type { HistoryEntry } from "./history.ts";
 import { t } from "./i18n.ts";
 import {
-  renderTransportLabel,
   renderSaveGuidance,
-  renderProgress,
   renderCompletion,
   formatElapsed,
-  formatRemaining,
   getDezoomifyLogoSvg,
 } from "./components.ts";
 
@@ -28,7 +25,8 @@ export interface ViewCallbacks {
   onSelectImage?(index: number): void;
   onSelectLevel?(level: number): void;
   onOpenExternalLink?(url: string): void;
-  onCopyShareLink?(): void;
+  /** Copy the current, host-supplied diagnostic snapshot. */
+  onCopyDiagnostics?(text: string): void;
   /** Clear the local history ledger. Absent hides the clear action. */
   onClearHistory?(): void;
   /** Pause the active job (suspend-acquisition). Absent hides the pause control. */
@@ -56,13 +54,22 @@ export interface JobActivity {
   lastProgressAt?: number;
   /** Capped technical log lines (oldest first). Never rendered unescaped. */
   log?: string[];
+  /** Extra bounded, redacted diagnostics supplied by the host runtime. */
+  diagnostics?: string;
   /** Pause v1 overlay (todo 5.7): true while acquisition is suspended. */
   paused?: boolean;
 }
 
 export interface ViewContext {
   capabilities?: AppCapabilities;
-  currentProgress?: { current: number; total: number; message?: string };
+  currentProgress?: {
+    current: number;
+    total: number;
+    active?: number;
+    retrying?: number;
+    estimatedTotalMs?: number;
+    message?: string;
+  };
   completedInfo?: { width: number; height: number; mime: string; blobUrl?: string };
   nativeSaved?: { partial: boolean };
   savedOutput?: {
@@ -650,6 +657,16 @@ function truncateMiddle(value: string, max = 90): string {
   return `${s.slice(0, half)}…${s.slice(s.length - half)}`;
 }
 
+/** Display source context without query, fragment, or credentials. */
+function displaySourceUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    return truncateMiddle(`${url.host}${url.pathname}`, 90);
+  } catch {
+    return "source unavailable";
+  }
+}
+
 /** The website a request is waiting on, for plain-language messages. */
 function hostFromUrl(url: string | undefined): string {
   try {
@@ -957,43 +974,27 @@ function mountJobSection(
   (sec as unknown as { _callbacks: ViewCallbacks })._callbacks = callbacks;
 
   sec.innerHTML = `
-    <p class="dz-source-line" id="dz-job-source-line" style="display: none;">
-      Working on <span class="dz-source-url" id="dz-job-source-url"></span>
-    </p>
+    <div class="dz-job-source-row" id="dz-job-source-line" style="display: none;">
+      <span class="dz-job-source-label">Source</span>
+      <span class="dz-source-url" id="dz-job-source-url"></span>
+      <span class="dz-job-time" id="dz-job-time"></span>
+    </div>
     <div class="dz-progress-header">
       <span class="dz-progress-status">
         <span class="dz-pulse" aria-hidden="true"></span>
         <span class="dz-progress-step-text" id="dz-job-step-text"></span>
       </span>
-      <span class="dz-progress-percent" id="dz-job-percent"></span>
+      <span class="dz-progress-count" id="dz-job-counts"></span>
     </div>
-    <div class="dz-progress-track dz-indeterminate" id="dz-job-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-      <div class="dz-progress-bar" id="dz-job-bar" style="width: 35%;"></div>
-    </div>
-    <p class="dz-tile-counts" id="dz-job-counts"></p>
-    <p class="dz-job-detail" id="dz-job-images" style="display: none;">
-      <span id="dz-job-images-text"></span>
-      <button type="button" class="dz-btn-link" id="dz-job-change">Change</button>
-    </p>
-    <p class="dz-job-detail" id="dz-job-change-hint" style="display: none;"></p>
-    <div class="dz-pending-box" id="dz-job-pending-box" style="display: none;">
-      <div class="dz-pending-line">
-        <span id="dz-job-pending-status"></span>
-        <span class="dz-pending-time" id="dz-job-pending-time"></span>
+    <div class="dz-progress-rail">
+      <div class="dz-progress-track dz-indeterminate" id="dz-job-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+        <div class="dz-progress-done" id="dz-job-bar" style="width: 0%;"></div>
+        <div class="dz-progress-active" id="dz-job-active" style="width: 0%;"></div>
       </div>
-      <div class="dz-remaining-track" aria-hidden="true">
-        <div class="dz-remaining-bar" id="dz-job-remaining-bar" style="width: 0%;"></div>
-      </div>
-    </div>
-    <p class="dz-reassure" id="dz-job-reassure" style="display: none;"></p>
-    <p class="dz-job-detail" id="dz-job-detail" style="display: none;"></p>
-    <div class="dz-progress-controls">
-      <span class="dz-transport-badge" id="dz-job-transport">Direct from your browser</span>
-      <div class="dz-job-actions">
-        <button type="button" class="dz-btn-secondary" id="dz-btn-share" style="display: none;">Copy shareable link</button>
-        <button type="button" class="dz-btn-secondary" id="dz-btn-pause" style="display: none;">Pause</button>
-        <button type="button" class="dz-btn-secondary" id="dz-btn-resume" style="display: none;">Resume</button>
-        <button type="button" class="dz-btn-secondary" id="dz-btn-cancel">Cancel</button>
+      <div class="dz-progress-buttons">
+        <button type="button" class="dz-progress-control" id="dz-btn-pause" style="display: none;" aria-label="Pause" title="Pause"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="5" width="4" height="14"></rect><rect x="14" y="5" width="4" height="14"></rect></svg></button>
+        <button type="button" class="dz-progress-control" id="dz-btn-resume" style="display: none;" aria-label="Resume" title="Resume"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8 5 11 7-11 7z"></path></svg></button>
+        <button type="button" class="dz-progress-control dz-stop-control" id="dz-btn-cancel" aria-label="Stop and return to start" title="Stop and return to start"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="6" width="12" height="12"></rect></svg></button>
       </div>
     </div>
     <details class="dz-details" id="dz-job-details">
@@ -1001,6 +1002,7 @@ function mountJobSection(
         <span>Technical details &amp; logs</span>
         <svg class="dz-summary-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
       </summary>
+      <button type="button" class="dz-copy-diagnostics" id="dz-btn-copy-diagnostics" style="display: none;" aria-label="Copy technical details" title="Copy technical details"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="10" height="11" rx="1"></rect><path d="M15 9V5H5v11h4"></path></svg></button>
       <div class="dz-diagnostics" id="dz-job-diagnostics"></div>
       <div class="dz-diagnostics dz-log" id="dz-job-log" style="display: none;"></div>
     </details>
@@ -1018,13 +1020,9 @@ function mountJobSection(
     const cb = (sec as unknown as { _callbacks: ViewCallbacks })._callbacks;
     cb?.onResume?.();
   });
-  sec.querySelector("#dz-btn-share")?.addEventListener("click", () => {
-    const cb = (sec as unknown as { _callbacks: ViewCallbacks })._callbacks;
-    cb?.onCopyShareLink?.();
-  });
-  sec.querySelector("#dz-job-change")?.addEventListener("click", () => {
-    const hint = sec.querySelector<HTMLElement>("#dz-job-change-hint");
-    if (hint) hint.style.display = hint.style.display === "none" ? "" : "none";
+  sec.querySelector("#dz-btn-copy-diagnostics")?.addEventListener("click", () => {
+    const stored = sec as unknown as { _callbacks: ViewCallbacks; _diagnostics?: string };
+    stored._callbacks?.onCopyDiagnostics?.(stored._diagnostics ?? "");
   });
 
   parent.appendChild(sec);
@@ -1049,26 +1047,37 @@ function updateJobSection(
   const current = ctx?.currentProgress?.current ?? 0;
   const total = ctx?.currentProgress?.total ?? 0;
   const determinate = total > 0;
-  const pct = determinate ? Math.max(0, Math.min(100, Math.round((current / total) * 100))) : 0;
-  const transport = state.transport ? renderTransportLabel(state.transport) : "Direct from your browser";
+  const donePct = determinate ? Math.max(0, Math.min(100, (current / total) * 100)) : 0;
+  const active = determinate
+    ? Math.max(0, Math.min(ctx?.currentProgress?.active ?? 0, Math.max(0, total - current)))
+    : 0;
+  const activePct = determinate ? (active / total) * 100 : 0;
+  const retrying = Math.max(0, Math.min(ctx?.currentProgress?.retrying ?? 0, active));
   const paused = ctx?.paused === true || activity.paused === true;
-  const step = paused
-    ? "Paused. No new pieces are being fetched."
-    : activity.stepLabel || ctx?.currentProgress?.message || defaultStepFor(state.status);
   const now = activity.now ?? Date.now();
   const startedAt = activity.startedAt ?? now;
   const elapsedMs = Math.max(0, now - startedAt);
   const elapsed = formatElapsed(elapsedMs);
-  const pending = activity.pendingRequests ?? 0;
-  const completed = activity.completedRequests ?? 0;
-  const failed = activity.failedRequests ?? 0;
-  const longestPending = activity.longestPendingMs ?? 0;
   const timeoutMs = activity.timeoutMs ?? 30000;
   const lastProgressAt = activity.lastProgressAt ?? startedAt;
   const stalledMs = Math.max(0, now - lastProgressAt);
-  const showPending = pending > 0 && (elapsedMs >= 2000 || longestPending >= 2000);
   const showStalled = stalledMs >= 10000 && state.status !== "saving";
-  const sourceUrl = activity.url ? truncateMiddle(activity.url, 90) : "";
+  const step = paused
+    ? "Paused"
+    : retrying > 0
+      ? `Retrying ${retrying} tile${retrying === 1 ? "" : "s"}…`
+      : showStalled
+        ? `Waiting for ${hostFromUrl(activity.url)}…`
+        : activity.stepLabel || ctx?.currentProgress?.message || defaultStepFor(state.status);
+  const sourceUrl = activity.url ? displaySourceUrl(activity.url) : "";
+  const estimatedTotalMs = ctx?.currentProgress?.estimatedTotalMs ?? (
+    determinate && current >= 2 && elapsedMs >= 2000
+      ? Math.round((elapsedMs / current) * total)
+      : undefined
+  );
+  const timeText = elapsed
+    ? `${elapsed}${typeof estimatedTotalMs === "number" && estimatedTotalMs > elapsedMs ? ` / ~${formatElapsed(estimatedTotalMs)}` : ""}`
+    : "";
 
   // 1. Source Line
   const sourceLine = sec.querySelector<HTMLElement>("#dz-job-source-line");
@@ -1076,7 +1085,7 @@ function updateJobSection(
   if (sourceLine && sourceUrlEl) {
     if (sourceUrl) {
       sourceLine.style.display = "";
-      sourceLine.title = activity.url ?? "";
+      sourceLine.title = sourceUrl;
       if (sourceUrlEl.textContent !== sourceUrl) {
         sourceUrlEl.textContent = sourceUrl;
       }
@@ -1084,147 +1093,48 @@ function updateJobSection(
       sourceLine.style.display = "none";
     }
   }
+  const timeEl = sec.querySelector<HTMLElement>("#dz-job-time");
+  if (timeEl && timeEl.textContent !== timeText) timeEl.textContent = timeText;
 
-  // 2. Step Label & Percent/Elapsed
+  // 2. Phase and exact tile summary.
   const stepEl = sec.querySelector<HTMLElement>("#dz-job-step-text");
   if (stepEl && stepEl.textContent !== step) {
     stepEl.textContent = step;
   }
 
-  const percentEl = sec.querySelector<HTMLElement>("#dz-job-percent");
-  if (percentEl) {
-    const percentText = determinate ? `${pct}%` : (elapsed || "");
-    if (percentEl.textContent !== percentText) {
-      percentEl.textContent = percentText;
-    }
-  }
+  const countsEl = sec.querySelector<HTMLElement>("#dz-job-counts");
+  const countsText = determinate
+    ? `${current} done${active > 0 ? ` + ${active} in progress` : ""} / ${total}`
+    : "";
+  if (countsEl && countsEl.textContent !== countsText) countsEl.textContent = countsText;
 
   // 3. Track and Bar
   const track = sec.querySelector<HTMLElement>("#dz-job-track");
   const bar = sec.querySelector<HTMLElement>("#dz-job-bar");
   if (track && bar) {
-    track.setAttribute("aria-valuenow", String(pct));
+    track.setAttribute("aria-valuenow", String(current));
+    track.setAttribute("aria-valuemax", String(total || 100));
     track.setAttribute("aria-label", step);
+    track.setAttribute(
+      "aria-valuetext",
+      determinate
+        ? `${current} done, ${active} in progress, ${Math.max(0, total - current - active)} remaining`
+        : step,
+    );
     if (determinate) {
       track.classList.remove("dz-indeterminate");
-      bar.style.width = `${pct}%`;
+      bar.style.width = `${donePct}%`;
     } else {
       track.classList.add("dz-indeterminate");
       bar.style.width = "35%";
     }
-  }
-
-  // 4. Counts
-  const countsEl = sec.querySelector<HTMLElement>("#dz-job-counts");
-  if (countsEl) {
-    const countsText = determinate
-      ? `${current} of ${total} tiles${elapsed ? ` · ${elapsed} elapsed` : ""}`
-      : elapsed
-        ? `${elapsed} elapsed`
-        : "";
-    if (countsEl.textContent !== countsText) {
-      countsEl.textContent = countsText;
+    const activeBar = sec.querySelector<HTMLElement>("#dz-job-active");
+    if (activeBar) {
+      activeBar.style.left = determinate ? `${donePct}%` : "0%";
+      activeBar.style.width = determinate ? `${activePct}%` : "0%";
     }
   }
-
-  // 4b. Catalog auto-choice notice (todo 4.3): honest step without a picker.
-  // Uses existing controller imageCount, never a new protocol event. WxH and
-  // tile counts come from local ViewContext.imageChoice when known.
-  const imagesEl = sec.querySelector<HTMLElement>("#dz-job-images");
-  const imagesText = sec.querySelector<HTMLElement>("#dz-job-images-text");
-  const changeHint = sec.querySelector<HTMLElement>("#dz-job-change-hint");
-  const choiceCount = state.imageCount ?? 0;
-  if (imagesEl && imagesText) {
-    if (choiceCount > 0) {
-      const choiceWidth = ctx?.imageChoice?.width ?? ctx?.completedInfo?.width ?? 0;
-      const choiceHeight = ctx?.imageChoice?.height ?? ctx?.completedInfo?.height ?? 0;
-      const choiceTiles = ctx?.imageChoice?.tiles ?? (determinate ? total : 0);
-      const noun = choiceCount === 1 ? "1 image" : `${choiceCount} images`;
-      let suffix = ".";
-      if (choiceWidth > 0 && choiceHeight > 0 && choiceTiles > 0) {
-        suffix = ` (${choiceWidth}×${choiceHeight}, ${choiceTiles} tiles).`;
-      } else if (choiceWidth > 0 && choiceHeight > 0) {
-        suffix = ` (${choiceWidth}×${choiceHeight}).`;
-      } else if (choiceTiles > 0) {
-        suffix = ` (${choiceTiles} tiles).`;
-      }
-      const notice = `Found ${noun}, saving largest that fits${suffix}`;
-      if (imagesText.textContent !== notice) imagesText.textContent = notice;
-      imagesEl.style.display = "";
-      if (changeHint) {
-        const hint = "The website saves the largest image automatically. To choose a different image, use the desktop app.";
-        if (changeHint.textContent !== hint) changeHint.textContent = hint;
-      }
-    } else {
-      imagesEl.style.display = "none";
-      if (changeHint) changeHint.style.display = "none";
-    }
-  }
-
-  // 5. Pending section
-  const pendingBox = sec.querySelector<HTMLElement>("#dz-job-pending-box");
-  const pendingStatus = sec.querySelector<HTMLElement>("#dz-job-pending-status");
-  const pendingTime = sec.querySelector<HTMLElement>("#dz-job-pending-time");
-  const remainingBar = sec.querySelector<HTMLElement>("#dz-job-remaining-bar");
-  if (pendingBox) {
-    if (showPending) {
-      pendingBox.style.display = "";
-      if (pendingStatus) {
-        const text = `${pending} request${pending === 1 ? "" : "s"} in flight${completed > 0 ? ` · ${completed} done` : ""}${failed > 0 ? ` · ${failed} failed, retrying` : ""}`;
-        if (pendingStatus.textContent !== text) {
-          pendingStatus.textContent = text;
-        }
-      }
-      if (pendingTime) {
-        const timeText = `${formatElapsed(longestPending)} waiting · ${formatRemaining(longestPending, timeoutMs)}`;
-        if (pendingTime.textContent !== timeText) {
-          pendingTime.textContent = timeText;
-        }
-      }
-      if (remainingBar) {
-        const remainingPct = Math.max(0, Math.min(100, Math.round((longestPending / timeoutMs) * 100)));
-        remainingBar.style.width = `${remainingPct}%`;
-      }
-    } else {
-      pendingBox.style.display = "none";
-    }
-  }
-
-  // 6. Stalled Reassurance
-  const reassureEl = sec.querySelector<HTMLElement>("#dz-job-reassure");
-  if (reassureEl) {
-    reassureEl.style.display = showStalled ? "" : "none";
-    const reassureText = `Still working, ${hostFromUrl(activity.url)} is slow to answer. You can wait, or cancel and try again later.`;
-    if (reassureEl.textContent !== reassureText) {
-      reassureEl.textContent = reassureText;
-    }
-  }
-
-  // 7. Detail
-  const detailEl = sec.querySelector<HTMLElement>("#dz-job-detail");
-  if (detailEl) {
-    if (activity.detail) {
-      detailEl.style.display = "";
-      if (detailEl.textContent !== activity.detail) {
-        detailEl.textContent = activity.detail;
-      }
-    } else {
-      detailEl.style.display = "none";
-    }
-  }
-
-  // 8. Transport badge & Action buttons
-  const transportEl = sec.querySelector<HTMLElement>("#dz-job-transport");
-  if (transportEl && transportEl.textContent !== transport) {
-    transportEl.textContent = transport;
-  }
-
-  const shareBtn = sec.querySelector<HTMLElement>("#dz-btn-share");
-  if (shareBtn) {
-    shareBtn.style.display = callbacks.onCopyShareLink ? "" : "none";
-  }
-
-  // Pause v1 (todo 5.7): suspend-acquisition controls. Pause shows while
+  // 4. Pause v1: acquisition controls belong to the rail itself. Pause shows while
   // running with a pause handler; Resume shows while paused with a resume
   // handler. Hosts own the effect; the view only renders the overlay.
   const pauseBtn = sec.querySelector<HTMLElement>("#dz-btn-pause");
@@ -1239,13 +1149,15 @@ function updateJobSection(
   }
 
   // 9. Diagnostics & Logs (preserved in-place, keeping details open state intact)
+  const diagText = diagnosticsText(state, ctx, elapsedMs, timeoutMs);
   const diagEl = sec.querySelector<HTMLElement>("#dz-job-diagnostics");
   if (diagEl) {
-    const diagText = diagnosticsText(state, ctx, elapsedMs, timeoutMs);
     if (diagEl.textContent !== diagText) {
       diagEl.textContent = diagText;
     }
   }
+  const copyBtn = sec.querySelector<HTMLElement>("#dz-btn-copy-diagnostics");
+  if (copyBtn) copyBtn.style.display = callbacks.onCopyDiagnostics ? "" : "none";
 
   const logEl = sec.querySelector<HTMLElement>("#dz-job-log");
   if (logEl) {
@@ -1259,6 +1171,8 @@ function updateJobSection(
       logEl.style.display = "none";
     }
   }
+  const copiedLog = activity.log && activity.log.length > 0 ? `\n\nEvents\n${activity.log.join("\n")}` : "";
+  (sec as unknown as { _diagnostics?: string })._diagnostics = `${diagText}${activity.diagnostics ? `\n\n${activity.diagnostics}` : ""}${copiedLog}`;
 }
 
 function diagnosticsText(
@@ -1277,7 +1191,9 @@ function diagnosticsText(
     `Requests: ${a.pendingRequests ?? 0} pending, ${a.completedRequests ?? 0} done, ${a.failedRequests ?? 0} failed`,
   ];
   if (p) lines.push(`Tiles: ${p.current} of ${p.total}`);
-  if (a.url) lines.push(`Source: ${a.url}`);
+  if (p?.active !== undefined) lines.push(`Tiles active: ${p.active}`);
+  if (p?.retrying !== undefined) lines.push(`Tiles retrying: ${p.retrying}`);
+  if (a.url) lines.push(`Source: ${displaySourceUrl(a.url)}`);
   return lines.join("\n");
 }
 
@@ -1462,7 +1378,6 @@ function mountCompletedSection(
         </svg>
         Save image
       </button>` : ""}
-      ${callbacks.onCopyShareLink ? `<button type="button" class="dz-btn-secondary" id="dz-btn-share">Copy shareable link</button>` : ""}
       <button type="button" class="dz-btn-secondary" id="dz-btn-another">Dezoomify another image</button>
     </div>
   `;
@@ -1470,7 +1385,6 @@ function mountCompletedSection(
   section.querySelector("#dz-btn-save")?.addEventListener("click", () => callbacks.onSave?.());
   section.querySelector("#dz-btn-open")?.addEventListener("click", () => callbacks.onOpenOutput?.());
   section.querySelector("#dz-btn-reveal")?.addEventListener("click", () => callbacks.onRevealOutput?.());
-  section.querySelector("#dz-btn-share")?.addEventListener("click", () => callbacks.onCopyShareLink?.());
   section.querySelector("#dz-btn-another")?.addEventListener("click", () => callbacks.onReset());
   parent.appendChild(section);
 }

--- a/packages/shared-ui/src/view.ts
+++ b/packages/shared-ui/src/view.ts
@@ -58,6 +58,10 @@ export interface JobActivity {
   diagnostics?: string;
   /** Pause v1 overlay (todo 5.7): true while acquisition is suspended. */
   paused?: boolean;
+  /** Epoch when the current pause began; keeps displayed durations frozen. */
+  pausedAt?: number;
+  /** Total completed pause time, excluded from displayed job durations. */
+  pausedDurationMs?: number;
 }
 
 export interface ViewContext {
@@ -987,14 +991,14 @@ function mountJobSection(
       <span class="dz-progress-count" id="dz-job-counts"></span>
     </div>
     <div class="dz-progress-rail">
-      <div class="dz-progress-track dz-indeterminate" id="dz-job-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-        <div class="dz-progress-done" id="dz-job-bar" style="width: 0%;"></div>
-        <div class="dz-progress-active" id="dz-job-active" style="width: 0%;"></div>
-      </div>
       <div class="dz-progress-buttons">
         <button type="button" class="dz-progress-control" id="dz-btn-pause" style="display: none;" aria-label="Pause" title="Pause"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="5" width="4" height="14"></rect><rect x="14" y="5" width="4" height="14"></rect></svg></button>
         <button type="button" class="dz-progress-control" id="dz-btn-resume" style="display: none;" aria-label="Resume" title="Resume"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m8 5 11 7-11 7z"></path></svg></button>
         <button type="button" class="dz-progress-control dz-stop-control" id="dz-btn-cancel" aria-label="Stop and return to start" title="Stop and return to start"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="6" width="12" height="12"></rect></svg></button>
+      </div>
+      <div class="dz-progress-track dz-indeterminate" id="dz-job-track" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+        <div class="dz-progress-done" id="dz-job-bar" style="width: 0%;"></div>
+        <div class="dz-progress-active" id="dz-job-active" style="width: 0%;"></div>
       </div>
     </div>
     <details class="dz-details" id="dz-job-details">
@@ -1054,13 +1058,16 @@ function updateJobSection(
   const activePct = determinate ? (active / total) * 100 : 0;
   const retrying = Math.max(0, Math.min(ctx?.currentProgress?.retrying ?? 0, active));
   const paused = ctx?.paused === true || activity.paused === true;
+  if (paused) sec.classList.add("dz-job-paused");
+  else sec.classList.remove("dz-job-paused");
   const now = activity.now ?? Date.now();
   const startedAt = activity.startedAt ?? now;
-  const elapsedMs = Math.max(0, now - startedAt);
+  const timerNow = activity.pausedAt ?? now;
+  const elapsedMs = Math.max(0, timerNow - startedAt - (activity.pausedDurationMs ?? 0));
   const elapsed = formatElapsed(elapsedMs);
   const timeoutMs = activity.timeoutMs ?? 30000;
   const lastProgressAt = activity.lastProgressAt ?? startedAt;
-  const stalledMs = Math.max(0, now - lastProgressAt);
+  const stalledMs = Math.max(0, timerNow - lastProgressAt);
   const showStalled = stalledMs >= 10000 && state.status !== "saving";
   const step = paused
     ? "Paused"

--- a/src/main.ts
+++ b/src/main.ts
@@ -449,6 +449,9 @@ let requestSeq = 0;
 const pendingStarts = new Map<number, { startedAt: number; label: string }>();
 let completedRequests = 0;
 let failedRequests = 0;
+let tileAttempts = 0;
+let tileRetries = 0;
+const metadataAttempts: Array<{ at: number; transport: string; target: string; outcome: string; durationMs: number; bytes?: number }> = [];
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 let batchedUpdateQueued = false;
 let lastHeartbeatKey = "";
@@ -491,6 +494,9 @@ function resetActivity(url: string): void {
   pendingStarts.clear();
   completedRequests = 0;
   failedRequests = 0;
+  tileAttempts = 0;
+  tileRetries = 0;
+  metadataAttempts.length = 0;
   const now = Date.now();
   viewCtx.jobActivity = {
     url,
@@ -506,6 +512,46 @@ function resetActivity(url: string): void {
     lastProgressAt: now,
     log: [],
   };
+}
+
+/** Keep diagnostics bounded and useful without retaining individual tile URLs. */
+function refreshDiagnostics(): void {
+  const a = activity();
+  const lines: string[] = [];
+  if (metadataAttempts.length > 0) {
+    lines.push("Metadata requests");
+    for (const attempt of metadataAttempts) {
+      const size = attempt.bytes === undefined ? "" : ` · ${Math.max(1, Math.round(attempt.bytes / 1024))} KB`;
+      lines.push(
+        `+${(attempt.at / 1000).toFixed(1)} s  ${attempt.target}  ${attempt.transport}  ${attempt.outcome}  ${attempt.durationMs} ms${size}`,
+      );
+    }
+  }
+  if (tileAttempts > 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push("Tile acquisition");
+    lines.push(`${tileAttempts} attempts · ${tileRetries} retries`);
+  }
+  a.diagnostics = lines.join("\n");
+}
+
+function recordMetadataAttempt(
+  startedAt: number,
+  transport: "direct" | "metadata proxy",
+  target: string,
+  outcome: string,
+  bytes?: number,
+): void {
+  metadataAttempts.push({
+    at: Math.max(0, startedAt - (activity().startedAt ?? startedAt)),
+    transport,
+    target,
+    outcome,
+    durationMs: Math.max(0, Date.now() - startedAt),
+    ...(typeof bytes === "number" ? { bytes } : {}),
+  });
+  if (metadataAttempts.length > 20) metadataAttempts.splice(0, metadataAttempts.length - 20);
+  refreshDiagnostics();
 }
 
 function touchProgress(): void {
@@ -673,6 +719,7 @@ async function fetchDirect(
   headers?: Record<string, string>,
   signal?: AbortSignal,
   ms: number = REQUEST_TIMEOUT_MS,
+  logTimeout: boolean = true,
 ): Promise<DirectOutcome> {
   const reqId = noteRequestStart("direct");
   const combined = timeoutSignal(signal, ms);
@@ -697,7 +744,7 @@ async function fetchDirect(
     if (signal?.aborted) return { outcome: "cancelled" };
     const name = (e as { name?: string })?.name;
     if (name === "TimeoutError" || (combined.timedOut && combined.timedOut())) {
-      pushLog(`Direct fetch did not complete within ${ms} ms: ${shortUrl(url)}`);
+      if (logTimeout) pushLog(`Direct metadata fetch did not complete within ${ms} ms: ${shortUrl(url)}`);
       return { outcome: "network-error" };
     }
     return { outcome: "network-error" };
@@ -954,7 +1001,15 @@ async function fetchMetadataFor(
   // AbortController dedupe: the direct loser is aborted before the proxy
   // starts so the two transports never overlap on the same resource.
   const directCtrl = new AbortController();
+  const directStartedAt = Date.now();
   const direct = await fetchDirect(url, headers, directCtrl.signal, DIRECT_METADATA_TIMEOUT_MS);
+  recordMetadataAttempt(
+    directStartedAt,
+    "direct",
+    target,
+    direct.outcome === "http-error" ? `HTTP ${direct.status ?? 0}` : direct.outcome,
+    direct.bytes?.byteLength,
+  );
   let via = "direct";
   let bytes: ArrayBuffer | null = null;
   let contentType: string | undefined;
@@ -980,7 +1035,15 @@ async function fetchMetadataFor(
     }
     activeTransport = PROXY_LABEL;
     via = "proxy";
+    let proxyStartedAt = Date.now();
     let proxied = await fetchViaProxy(url);
+    recordMetadataAttempt(
+      proxyStartedAt,
+      "metadata proxy",
+      target,
+      proxied.ok ? `HTTP ${proxied.status}` : proxied.code ?? `HTTP ${proxied.status}`,
+      proxied.bytes?.byteLength,
+    );
     // Retry-After + backoff: one bounded retry converts a transient
     // token-bucket 429 into success. A persistent throttle, or a
     // Retry-After beyond the UX budget, still fails fast below with the
@@ -990,7 +1053,15 @@ async function fetchMetadataFor(
       if (delay !== null) {
         pushLog(`Metadata proxy rate-limited; retrying once after ${delay} ms.`);
         await sleep(delay);
+        proxyStartedAt = Date.now();
         proxied = await fetchViaProxy(url);
+        recordMetadataAttempt(
+          proxyStartedAt,
+          "metadata proxy",
+          target,
+          proxied.ok ? `HTTP ${proxied.status}` : proxied.code ?? `HTTP ${proxied.status}`,
+          proxied.bytes?.byteLength,
+        );
       }
     }
     if (!proxied.ok || !proxied.bytes) {
@@ -1055,7 +1126,10 @@ async function fetchTileFor(
   let lastStatus: number | undefined;
   for (let attempt = 0; ; attempt++) {
     await throttleTileStart(url);
-    const direct = await fetchDirect(url, headers);
+    tileAttempts += 1;
+    if (attempt > 0) tileRetries += 1;
+    refreshDiagnostics();
+    const direct = await fetchDirect(url, headers, undefined, REQUEST_TIMEOUT_MS, false);
     if (direct.outcome === "readable" && direct.bytes) {
       return { bytes: direct.bytes };
     }
@@ -1071,7 +1145,7 @@ async function fetchTileFor(
     "Part of the image could not be saved. Try again in a moment.",
     true,
     undefined,
-    `tile fetch: ${lastOutcome} (HTTP ${lastStatus ?? "n/a"}) from ${shortUrl(url)} after ${maxRetries + 1} attempts`,
+    `tile fetch: ${lastOutcome} (HTTP ${lastStatus ?? "n/a"}) after ${maxRetries + 1} attempts`,
   );
 }
 
@@ -1120,7 +1194,7 @@ function loadTileImage(url: string, ms: number = REQUEST_TIMEOUT_MS): Promise<HT
     img.addEventListener("load", () => done(true, img), { once: true });
     img.addEventListener(
       "error",
-      () => done(false, new Error(`tile image failed to load: ${shortUrl(url)}`)),
+      () => done(false, new Error("tile image failed to load")),
       { once: true },
     );
     timer = setTimeout(() => {
@@ -1129,7 +1203,7 @@ function loadTileImage(url: string, ms: number = REQUEST_TIMEOUT_MS): Promise<HT
       } catch {
         // Cancelling a hung load must never throw.
       }
-      done(false, new Error(`tile image timed out after ${ms / 1000}s: ${shortUrl(url)}`));
+      done(false, new Error(`tile image timed out after ${ms / 1000}s`));
     }, ms);
     // Don't tell the tile host the request comes from dezoomify (legacy parity).
     img.referrerPolicy = "no-referrer";
@@ -1262,14 +1336,12 @@ async function drawTile(
     const fullW = source instanceof ImageBitmap ? source.width : source.naturalWidth;
     const fullH = source instanceof ImageBitmap ? source.height : source.naturalHeight;
     // Trust the plan for placement: the canvas layout must stay seamless even
-    // when a tile decodes at an unexpected size. Log the mismatch and scale
-    // the decoded bytes to the planned extent so no gap appears.
+    // when a tile decodes at an unexpected size. Scale the decoded bytes to
+    // the planned extent so no gap appears; diagnostics never retain tile data.
     const planW = tile.w ?? fullW;
     const planH = tile.h ?? fullH;
     if (planW !== fullW || planH !== fullH) {
-      pushLog(
-        `tile size mismatch at ${tile.x},${tile.y}: plan ${planW}x${planH}, decoded ${fullW}x${fullH} from ${shortUrl(tile.uri)}`,
-      );
+      pushLog("A tile size differed from the plan; it was scaled to keep the image seamless.");
     }
     if (planW > 0 && planH > 0 && fullW > 0 && fullH > 0) {
       ctx2d.drawImage(source, 0, 0, fullW, fullH, tile.x, tile.y, planW, planH);
@@ -1447,7 +1519,7 @@ async function runJob(url: string): Promise<void> {
 
     const total = plan.tiles.length;
     viewCtx.imageChoice = { width, height, tiles: total };
-    setStep("Saving image tiles…", `${total} tiles at full resolution`);
+    setStep("Fetching image tiles…", `${total} tiles at full resolution`);
     reportProgress(0, total, `Saving ${total} tiles…`);
     let done = 0;
     let failed: unknown = null;
@@ -1662,6 +1734,10 @@ let viewCtx: ViewContext = {
 function update(): void {
   if (!appContainer) return;
   const state = controller.getState();
+  if (state.status === "downloading" && viewCtx.currentProgress) {
+    const progress = viewCtx.currentProgress;
+    progress.active = Math.min(pendingStarts.size, Math.max(0, progress.total - progress.current));
+  }
   if (activeTransport && !state.transport) {
     state.transport = activeTransport;
   }
@@ -1731,22 +1807,28 @@ function update(): void {
         viewCtx.paused = false;
         stopHeartbeat();
         disposeClient();
-        controller.dispatch(nextEvent("cancel") as never);
-        // Queue: the active entry is cancelled, then the first waiting entry
-        // (if any) starts. Cancellation never issues new work beyond the
-        // already-queued line.
+        // Stop returns directly to the initial view. Effects from the retired
+        // token finish harmlessly without mutating the replacement job.
         if (webQueueEnabled()) {
-          const settled = finishActiveWebEntry(webQueue, "cancelled");
-          webQueue = settled.queue;
-          const next = settled.next;
-          if (next) {
-            controller.reset(sessionId);
-            currentSeq = 0;
-            pushLog(`Queue: starting next queued job (${shortUrl(next.url)})`);
-            void runJob(next.url);
-            update();
-            return;
-          }
+          webQueue = cancelAllWeb(webQueue);
+          webQueue = createWebQueue();
+        }
+        sessionId = `sess:web-${Date.now()}`;
+        controller.reset(sessionId);
+        currentSeq = 0;
+        viewCtx.currentProgress = undefined;
+        viewCtx.completedInfo = undefined;
+        viewCtx.jobActivity = undefined;
+        viewCtx.initialUrl = undefined;
+        viewCtx.imageChoice = undefined;
+        viewCtx.sourceUrl = undefined;
+        viewCtx.desktopHandoffUrl = undefined;
+        activeTransport = null;
+        setCanvasVisible(false);
+        clearHash();
+        if (resultBlobUrl) {
+          URL.revokeObjectURL(resultBlobUrl);
+          resultBlobUrl = null;
         }
         update();
       },
@@ -1803,15 +1885,18 @@ function update(): void {
         anchor.click();
         anchor.remove();
       },
-      onCopyShareLink() {
-        const href = (typeof window !== "undefined" && window.location && window.location.href) || "";
-        const btn = document.getElementById("dz-btn-share");
+      onCopyDiagnostics(text: string) {
+        const btn = document.getElementById("dz-btn-copy-diagnostics");
         const done = () => {
           if (btn) {
-            btn.textContent = "Copied!";
+            btn.setAttribute("title", "Copied");
+            btn.setAttribute("aria-label", "Copied");
             setTimeout(() => {
               try {
-                if (btn.isConnected) btn.textContent = "Copy shareable link";
+                if (btn.isConnected) {
+                  btn.setAttribute("title", "Copy technical details");
+                  btn.setAttribute("aria-label", "Copy technical details");
+                }
               } catch {
                 // Button may be gone after re-render; ignore.
               }
@@ -1820,10 +1905,10 @@ function update(): void {
         };
         try {
           if (navigator.clipboard && navigator.clipboard.writeText) {
-            (navigator.clipboard.writeText(href) as Promise<void>).then(done, done);
-          } else if (href) {
+            (navigator.clipboard.writeText(text) as Promise<void>).then(done, done);
+          } else if (text) {
             const ta = document.createElement("textarea");
-            ta.value = href;
+            ta.value = text;
             document.body.appendChild(ta);
             ta.select();
             document.execCommand("copy");

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import {
 } from "../packages/shared-ui/src/history.ts";
 import type { HistoryEntry } from "../packages/shared-ui/src/history.ts";
 import { renderView, showDesktopAppGuidance, showExtensionGuidance } from "../packages/shared-ui/src/view.ts";
-import type { ViewContext } from "../packages/shared-ui/src/view.ts";
+import type { JobActivity, ViewContext } from "../packages/shared-ui/src/view.ts";
 import { suggestedNameFor } from "../packages/shared-ui/src/saveName.ts";
 import {
   RATE_LIMITED_BY_SITE_MESSAGE,
@@ -490,6 +490,11 @@ function activity(): NonNullable<ViewContext["jobActivity"]> {
   return viewCtx.jobActivity as NonNullable<ViewContext["jobActivity"]>;
 }
 
+function activityElapsedMs(a: JobActivity, now = Date.now()): number {
+  const startedAt = a.startedAt ?? now;
+  return Math.max(0, (a.pausedAt ?? now) - startedAt - (a.pausedDurationMs ?? 0));
+}
+
 function resetActivity(url: string): void {
   pendingStarts.clear();
   completedRequests = 0;
@@ -569,7 +574,7 @@ function setStep(label: string, detail?: string): void {
 function pushLog(line: string): void {
   const a = activity();
   if (!a.log) a.log = [];
-  const elapsed = a.startedAt ? Math.round((Date.now() - a.startedAt) / 1000) : 0;
+  const elapsed = Math.round(activityElapsedMs(a) / 1000);
   a.log.push(`${elapsed}s: ${line}`);
   if (a.log.length > 60) a.log.splice(0, a.log.length - 60);
 }
@@ -596,8 +601,9 @@ function noteRequestEnd(id: number, ok: boolean): void {
 }
 
 function refreshLongestPending(): void {
-  const a = activity();
-  const now = Date.now();
+  const a = viewCtx.jobActivity;
+  if (!a) return;
+  const now = a.pausedAt ?? Date.now();
   a.now = now;
   let longest = 0;
   for (const { startedAt } of pendingStarts.values()) {
@@ -1789,7 +1795,12 @@ function update(): void {
         if (jobPaused) return;
         jobPaused = true;
         viewCtx.paused = true;
-        if (viewCtx.jobActivity) viewCtx.jobActivity.paused = true;
+        if (viewCtx.jobActivity) {
+          viewCtx.jobActivity.paused = true;
+          viewCtx.jobActivity.pausedAt = Date.now();
+          viewCtx.jobActivity.now = viewCtx.jobActivity.pausedAt;
+        }
+        stopHeartbeat();
         pushLog("Paused: no new pieces are being fetched.");
         update();
       },
@@ -1797,7 +1808,18 @@ function update(): void {
         if (!jobPaused) return;
         jobPaused = false;
         viewCtx.paused = false;
-        if (viewCtx.jobActivity) viewCtx.jobActivity.paused = false;
+        if (viewCtx.jobActivity) {
+          const now = Date.now();
+          const pausedAt = viewCtx.jobActivity.pausedAt;
+          const pausedFor = pausedAt === undefined ? 0 : Math.max(0, now - pausedAt);
+          viewCtx.jobActivity.paused = false;
+          viewCtx.jobActivity.pausedAt = undefined;
+          viewCtx.jobActivity.pausedDurationMs = (viewCtx.jobActivity.pausedDurationMs ?? 0) + pausedFor;
+          viewCtx.jobActivity.lastProgressAt = (viewCtx.jobActivity.lastProgressAt ?? now) + pausedFor;
+          viewCtx.jobActivity.now = now;
+          for (const pending of pendingStarts.values()) pending.startedAt += pausedFor;
+        }
+        startHeartbeat();
         pushLog("Resumed: fetching queued pieces again.");
         update();
       },

--- a/test/integration.test.mjs
+++ b/test/integration.test.mjs
@@ -384,9 +384,9 @@ test("shipped webapp paints unreadable ordinary tiles instead of failing", () =>
 
 test("website trusts the tile plan, warns on color profiles, and compresses PNG", () => {
   const mainTs = fs.readFileSync(path.join(REPO_ROOT, "src", "main.ts"), "utf8");
-  // Seam: the plan wins for placement; a mis-sized decode is logged and scaled
-  // to the planned extent so no gap appears (no Math.min clipping to the decode).
-  assert.ok(mainTs.includes("tile size mismatch"), "drawTile must log plan/decode mismatches");
+  // Seam: the plan wins for placement; a mis-sized decode is logged generically
+  // and scaled to the planned extent so no gap appears (no Math.min clipping to the decode).
+  assert.ok(mainTs.includes("A tile size differed from the plan"), "drawTile must log plan/decode mismatches without identifying a tile");
   assert.ok(!mainTs.includes("Math.min(tile.w"), "drawTile must trust the plan, not clip to the decode");
   assert.ok(
     mainTs.includes("drawImage(source, 0, 0, fullW, fullH, tile.x, tile.y, planW, planH)"),
@@ -416,5 +416,5 @@ test("website trusts the tile plan, warns on color profiles, and compresses PNG"
     path.join(REPO_ROOT, "packages", "browser-runtime", "src", "tile-draw.ts"),
     "utf8",
   );
-  assert.ok(tileDrawTs.includes("tile size mismatch"), "shared extension assembly must log plan/decode mismatches");
+  assert.ok(tileDrawTs.includes("A tile size differed from the plan"), "shared extension assembly must log plan/decode mismatches without identifying a tile");
 });

--- a/test/ui-a11y.test.mjs
+++ b/test/ui-a11y.test.mjs
@@ -286,10 +286,11 @@ test("static accessibility contract: live job region announces progress with a l
   const track = card.querySelector("#dz-job-track");
   assert.equal(track.getAttribute("role"), "progressbar");
   assert.equal(track.getAttribute("aria-valuemin"), "0");
-  assert.equal(track.getAttribute("aria-valuemax"), "100");
+  assert.equal(track.getAttribute("aria-valuemax"), "12");
   const now = Number(track.getAttribute("aria-valuenow"));
-  assert.ok(Number.isFinite(now) && now >= 0 && now <= 100, "aria-valuenow stays within bounds");
+  assert.ok(Number.isFinite(now) && now >= 0 && now <= 12, "aria-valuenow stays within bounds");
   assert.ok((track.getAttribute("aria-label") || "").length > 0, "progressbar has an accessible name");
+  assert.equal(track.getAttribute("aria-valuetext"), "3 done, 0 in progress, 9 remaining");
   assertButtonsNamed(card, "job");
 });
 

--- a/test/view-rendering.test.mjs
+++ b/test/view-rendering.test.mjs
@@ -302,8 +302,8 @@ test("renderView mounts card and updates job section in place without DOM destru
 
   // - Targeted element text and attributes updated in place
   assert.equal(stepTextEl.textContent, "Downloading image tiles…");
-  const percentEl = card.querySelector("#dz-job-percent");
-  assert.equal(percentEl.textContent, "25%");
+  const countsEl = card.querySelector("#dz-job-counts");
+  assert.equal(countsEl.textContent, "15 done / 60");
   const barEl = card.querySelector("#dz-job-bar");
   assert.equal(barEl.style.width, "25%");
 
@@ -346,7 +346,7 @@ test("renderView mounts card and updates job section in place without DOM destru
   assert.ok(card.querySelector(".dz-form"), "idle form re-mounted after reset");
 });
 
-test("stalled reassurance names the website being waited on, never a generic server", () => {
+test("slow discovery replaces the phase with one waiting status", () => {
   const container = createMockElement("div");
   const callbacks = {
     onSubmitUrl: () => {},
@@ -373,14 +373,13 @@ test("stalled reassurance names the website being waited on, never a generic ser
     ctx,
   );
   const card = container.querySelector(".dz-card");
-  const reassure = card.querySelector("#dz-job-reassure");
-  assert.ok(reassure, "reassurance shown while stalled");
-  assert.notEqual(reassure.style.display, "none");
+  const step = card.querySelector("#dz-job-step-text");
+  assert.ok(step, "job status shown while stalled");
   assert.equal(
-    reassure.textContent,
-    "Still working, artsandculture.google.com is slow to answer. You can wait, or cancel and try again later.",
+    step.textContent,
+    "Waiting for artsandculture.google.com…",
   );
-  assert.doesNotMatch(reassure.textContent, /museum/i);
+  assert.doesNotMatch(step.textContent, /museum/i);
 });
 
 test("failed state updates error details in place without destroying error container", () => {
@@ -470,7 +469,7 @@ test("error layering: plain message prominent, engine diagnostics only in techni
   assert.ok(!diag2.includes("no discovery candidate"), "stale detail must be replaced");
 });
 
-test("Change button during job is styled as a link button, and header visibility tracks phase", () => {
+test("job rail keeps integrated stop and diagnostics-copy controls, and header visibility tracks phase", () => {
   const container = createMockElement("div");
   const callbacks = {
     onSubmitUrl: () => {},
@@ -486,7 +485,7 @@ test("Change button during job is styled as a link button, and header visibility
   assert.ok(header, "header exists");
   assert.equal(header.style.display, "", "header visible in idle");
 
-  // 2. Job phase: header is hidden, Change button has dz-btn-link class
+  // 2. Job phase: header is hidden and compact job controls are mounted.
   renderView(
     container,
     { status: "downloading", seq: 2, sessionId: "s1", imageCount: 2, transport: "direct" },
@@ -497,10 +496,11 @@ test("Change button during job is styled as a link button, and header visibility
     },
   );
   assert.equal(header.style.display, "none", "header hidden in job phase");
-  const changeBtn = card.querySelector("#dz-job-change");
-  assert.ok(changeBtn, "change button exists");
-  assert.ok(changeBtn.classList.contains("dz-btn-link"), "change button has dz-btn-link class");
-  assert.ok(!changeBtn.classList.contains("dz-btn-secondary"), "change button is not a huge secondary button");
+  const stopBtn = card.querySelector("#dz-btn-cancel");
+  assert.ok(stopBtn, "stop button exists on the progress rail");
+  assert.ok(stopBtn.classList.contains("dz-progress-control"), "stop button uses compact rail-control styling");
+  const copyBtn = card.querySelector("#dz-btn-copy-diagnostics");
+  assert.ok(copyBtn, "technical details include a diagnostics copy control");
 
   // 3. Failed phase: header is hidden
   renderView(
@@ -522,9 +522,9 @@ test("CSS structural invariants prevent button clipping, container overflow, and
   assert.match(css, /\.dz-btn-secondary\s*\{[^}]*min-height:\s*38px;/);
   assert.doesNotMatch(css, /\.dz-btn-secondary\s*\{[^}]*(?<![a-z-])height:\s*38px;/);
 
-  // Progress controls and job actions must wrap and avoid squeezing elements into overlapping
-  assert.match(css, /\.dz-progress-controls\s*\{[^}]*flex-wrap:\s*wrap;/);
-  assert.match(css, /\.dz-job-actions\s*\{[^}]*flex-wrap:\s*wrap;/);
+  // The compact rail reserves a fixed, reachable control group.
+  assert.match(css, /\.dz-progress-rail\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto;/);
+  assert.match(css, /\.dz-progress-buttons\s*\{[^}]*display:\s*flex;/);
 
   // Link button styling for inline actions like Change button
   assert.match(css, /\.dz-btn-link,\s*\.dz-link-button\s*\{[^}]*display:\s*inline;/);
@@ -534,12 +534,9 @@ test("CSS structural invariants prevent button clipping, container overflow, and
   // Guidance items must not have broken disconnected border-top lines
   assert.doesNotMatch(css, /\.dz-guidance-item,\s*\.dz-suggestion-card\s*\{[^}]*border-top:/);
 
-  // Transport badge must be bounded and not stretch parent container
-  assert.match(css, /\.dz-transport-badge\s*\{[^}]*max-width:\s*100%;/);
-
-  // Progress percentage must never shrink or cause layout jitter
-  assert.match(css, /\.dz-progress-percent\s*\{[^}]*flex-shrink:\s*0;/);
-  assert.match(css, /\.dz-progress-percent\s*\{[^}]*tabular-nums;/);
+  // The count is stable-width enough not to cause layout jitter.
+  assert.match(css, /\.dz-progress-percent,\s*\.dz-progress-count\s*\{[^}]*flex-shrink:\s*0;/);
+  assert.match(css, /\.dz-progress-percent,\s*\.dz-progress-count\s*\{[^}]*tabular-nums;/);
 
   // Status step text must have min-width: 0 to truncate cleanly instead of overflowing
   assert.match(css, /\.dz-progress-status\s*\{[^}]*min-width:\s*0;/);

--- a/test/view-rendering.test.mjs
+++ b/test/view-rendering.test.mjs
@@ -515,6 +515,29 @@ test("job rail keeps integrated stop and diagnostics-copy controls, and header v
   assert.equal(header.style.display, "", "header reappears in idle");
 });
 
+test("paused job activity freezes the displayed elapsed time", () => {
+  const container = createMockElement("div");
+  const callbacks = {
+    onSubmitUrl: () => {},
+    onCancel: () => {},
+    onReset: () => {},
+  };
+  renderView(
+    container,
+    { status: "downloading", seq: 1, sessionId: "s1", imageCount: 1, transport: "direct" },
+    callbacks,
+    {
+      currentProgress: { current: 3, total: 10 },
+      paused: true,
+      jobActivity: { startedAt: 1_000, pausedAt: 4_000, now: 12_000, paused: true },
+    },
+  );
+
+  const card = container.querySelector(".dz-card");
+  assert.match(card.querySelector("#dz-job-time").textContent, /^3 s/);
+  assert.ok(card.querySelector(".dz-job-section").classList.contains("dz-job-paused"));
+});
+
 test("CSS structural invariants prevent button clipping, container overflow, and layout shifts", () => {
   const css = fs.readFileSync(path.join(rootDir, "packages/shared-ui/src/styles/theme.css"), "utf8");
 
@@ -522,9 +545,11 @@ test("CSS structural invariants prevent button clipping, container overflow, and
   assert.match(css, /\.dz-btn-secondary\s*\{[^}]*min-height:\s*38px;/);
   assert.doesNotMatch(css, /\.dz-btn-secondary\s*\{[^}]*(?<![a-z-])height:\s*38px;/);
 
-  // The compact rail reserves a fixed, reachable control group.
-  assert.match(css, /\.dz-progress-rail\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto;/);
+  // The compact rail places its bare icon controls before the progress line.
+  assert.match(css, /\.dz-progress-rail\s*\{[^}]*grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\);/);
   assert.match(css, /\.dz-progress-buttons\s*\{[^}]*display:\s*flex;/);
+  assert.match(css, /\.dz-progress-control\s*\{[^}]*border:\s*0;/);
+  assert.match(css, /\.dz-progress-control\s*\{[^}]*background:\s*transparent;/);
 
   // Link button styling for inline actions like Change button
   assert.match(css, /\.dz-btn-link,\s*\.dz-link-button\s*\{[^}]*display:\s*inline;/);


### PR DESCRIPTION
## Summary
- replace the active-job display with source context, elapsed/estimated time, segmented progress, and integrated pause/stop controls
- add copyable bounded diagnostics with metadata timing and aggregate tile acquisition counts
- redact source and tile-specific diagnostics across website and extension runtime paths

## Validation
- cargo xtask test
- cargo xtask ci check
- cargo xtask ci local
- cargo xtask test extension