### PR TITLE
fix(web): handle tainted canvas saves

### DIFF
--- a/apps/extension/src/vendor/controller.js
+++ b/apps/extension/src/vendor/controller.js
@@ -35,7 +35,12 @@ const TRANSITIONS                                                               
     cancel: "cancelled",
   },
   "display-only": { cancel: "cancelled", fail: "failed", reset: "idle" },
-  saving: { "save-done": "completed", fail: "failed", cancel: "cancelled" },
+  saving: {
+    "save-done": "completed",
+    "preflight-display-only": "display-only",
+    fail: "failed",
+    cancel: "cancelled",
+  },
   completed: { reset: "idle" },
   cancelled: { reset: "idle" },
   failed: { reset: "idle", "start-discovery": "discovering" },

--- a/apps/extension/src/vendor/failure.js
+++ b/apps/extension/src/vendor/failure.js
@@ -8,6 +8,13 @@
 // plan gates) can raise typed failures without depending on the discovery
 // client. Keep erasable-syntax-only for the browser `.js` mirrors.
 
+/** Return a stable string code from an arbitrary host-side failure. */
+export function stableErrorCode(error         , fallback = "DISCOVERY_FAILED")         {
+  if (!error || typeof error !== "object") return fallback;
+  const code = (error                      ).code;
+  return typeof code === "string" && code !== "" ? code : fallback;
+}
+
 export function failure(
   code        ,
   message        ,

--- a/apps/extension/src/vendor/plan-gates.js
+++ b/apps/extension/src/vendor/plan-gates.js
@@ -164,7 +164,8 @@ export function isLocalFileUrl(urlString        )          {
 }
 
 /** Stable error classification derived from the code, never from text. */
-export function categoryFor(code        )         {
+export function categoryFor(code         )         {
+  if (typeof code !== "string") return "transport";
   if (code === "NO_IMAGE_FOUND") return "discovery";
   if (code === "INVALID_URL") return "validation";
   if (code.startsWith("OUTPUT_")) return "output";
@@ -172,7 +173,8 @@ export function categoryFor(code        )         {
   return "transport";
 }
 
-export function phaseFor(code        )         {
+export function phaseFor(code         )         {
+  if (typeof code !== "string") return "acquisition";
   if (code === "NO_IMAGE_FOUND") return "discovery";
   if (code.startsWith("OUTPUT_")) return "output";
   return "acquisition";

--- a/packages/browser-runtime/src/failure.ts
+++ b/packages/browser-runtime/src/failure.ts
@@ -17,6 +17,13 @@ export interface StructuredFailure extends Error {
   technical?: string;
 }
 
+/** Return a stable string code from an arbitrary host-side failure. */
+export function stableErrorCode(error: unknown, fallback = "DISCOVERY_FAILED"): string {
+  if (!error || typeof error !== "object") return fallback;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" && code !== "" ? code : fallback;
+}
+
 export function failure(
   code: string,
   message: string,

--- a/packages/browser-runtime/src/plan-gates.ts
+++ b/packages/browser-runtime/src/plan-gates.ts
@@ -165,7 +165,8 @@ export function isLocalFileUrl(urlString: string): boolean {
 }
 
 /** Stable error classification derived from the code, never from text. */
-export function categoryFor(code: string): string {
+export function categoryFor(code: unknown): string {
+  if (typeof code !== "string") return "transport";
   if (code === "NO_IMAGE_FOUND") return "discovery";
   if (code === "INVALID_URL") return "validation";
   if (code.startsWith("OUTPUT_")) return "output";
@@ -173,7 +174,8 @@ export function categoryFor(code: string): string {
   return "transport";
 }
 
-export function phaseFor(code: string): string {
+export function phaseFor(code: unknown): string {
+  if (typeof code !== "string") return "acquisition";
   if (code === "NO_IMAGE_FOUND") return "discovery";
   if (code.startsWith("OUTPUT_")) return "output";
   return "acquisition";

--- a/packages/browser-runtime/test/canvas-save.test.mjs
+++ b/packages/browser-runtime/test/canvas-save.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { BROWSER_SAVE_COLOR_WARNING, canvasToPngBlob, saveBlobViaAnchor } from "../src/canvas-save.ts";
+import { stableErrorCode } from "../src/failure.ts";
 
 test("canvasToPngBlob resolves the encoded blob", async () => {
   const blob = await canvasToPngBlob({ toBlob: (cb) => cb({ kind: "png" }), });
@@ -16,6 +17,12 @@ test("canvasToPngBlob maps null and throws to OUTPUT_ENCODE_FAILED", async () =>
     assert.equal(e.code, "OUTPUT_ENCODE_FAILED");
     return true;
   });
+});
+
+test("stableErrorCode ignores browser exception numeric codes", () => {
+  assert.equal(stableErrorCode({ code: 18, name: "SecurityError" }), "DISCOVERY_FAILED");
+  assert.equal(stableErrorCode({ code: "TILE_FAILED" }), "TILE_FAILED");
+  assert.equal(stableErrorCode(null), "DISCOVERY_FAILED");
 });
 
 test("saveBlobViaAnchor downloads the suggested WxH name", () => {

--- a/packages/browser-runtime/test/plan-gates.test.mjs
+++ b/packages/browser-runtime/test/plan-gates.test.mjs
@@ -73,7 +73,10 @@ test("error classification derives from codes, never text", () => {
   assert.equal(categoryFor("OUTPUT_ENCODE_FAILED"), "output");
   assert.equal(categoryFor("PLAN_INVALID"), "internal");
   assert.equal(categoryFor("TILE_FAILED"), "transport");
+  assert.equal(categoryFor({ code: "OUTPUT_ENCODE_FAILED" }), "transport");
+  assert.equal(categoryFor(null), "transport");
   assert.equal(phaseFor("NO_IMAGE_FOUND"), "discovery");
   assert.equal(phaseFor("OUTPUT_DENIED"), "output");
   assert.equal(phaseFor("TILE_FAILED"), "acquisition");
+  assert.equal(phaseFor({ code: "OUTPUT_DENIED" }), "acquisition");
 });

--- a/packages/shared-ui/src/controller.ts
+++ b/packages/shared-ui/src/controller.ts
@@ -86,7 +86,12 @@ const TRANSITIONS: Record<UiStatus, Partial<Record<ControllerEventKind, UiStatus
     cancel: "cancelled",
   },
   "display-only": { cancel: "cancelled", fail: "failed", reset: "idle" },
-  saving: { "save-done": "completed", fail: "failed", cancel: "cancelled" },
+  saving: {
+    "save-done": "completed",
+    "preflight-display-only": "display-only",
+    fail: "failed",
+    cancel: "cancelled",
+  },
   completed: { reset: "idle" },
   cancelled: { reset: "idle" },
   failed: { reset: "idle", "start-discovery": "discovering" },

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,11 +28,11 @@ import { errorTransportFor, isOrdinaryImageTile, isProxyEligible } from "./webIn
 import { createProxyTransport, PROXY_METADATA_MAX_BYTES } from "./proxyTransport.ts";
 import {
   createDiscoveryClient,
-  failure,
   type DiscoveryClient,
   type PlanTile,
   type WebCatalog,
 } from "../packages/browser-runtime/src/session.ts";
+import { failure, stableErrorCode } from "../packages/browser-runtime/src/failure.ts";
 import {
   BROWSER_LIMITS,
   BROWSER_MAX_CANVAS_AREA,
@@ -42,8 +42,10 @@ import {
 import {
   assertDeclaredSizeFitsBrowser,
   assertPlanFitsBrowser,
+  categoryFor,
   desktopHandoffLink,
   mapWorkerLimitExceeded,
+  phaseFor,
 } from "../packages/browser-runtime/src/plan-gates.ts";
 import { pickEngineSelection } from "../packages/browser-runtime/src/engine-selection.ts";
 import {
@@ -1166,19 +1168,11 @@ function setCanvasVisible(visible: boolean): void {
   }
 }
 
-/** Stable error classification derived from the code, never from text. */
-function categoryFor(code: string): string {
-  if (code === "NO_IMAGE_FOUND") return "discovery";
-  if (code === "INVALID_URL") return "validation";
-  if (code.startsWith("OUTPUT_")) return "output";
-  if (code === "WORKER_FAILED" || code === "PLAN_INVALID") return "internal";
-  return "transport";
-}
-
-function phaseFor(code: string): string {
-  if (code === "NO_IMAGE_FOUND") return "discovery";
-  if (code.startsWith("OUTPUT_")) return "output";
-  return "acquisition";
+/** A browser canvas reports taint as a SecurityError when serialization is attempted. */
+function isCanvasTaintError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { name?: unknown; code?: unknown };
+  return candidate.name === "SecurityError" || candidate.code === 18;
 }
 
 function disposeClient(): void {
@@ -1452,6 +1446,19 @@ async function runJob(url: string): Promise<void> {
     let done = 0;
     let failed: unknown = null;
     let tainted = false;
+    const finishDisplayOnly = (): void => {
+      viewCtx.originClean = false;
+      viewCtx.sourceUrl = url;
+      viewCtx.desktopHandoffUrl = desktopHandoffLink(url);
+      setStep("Displaying the image…", "This site shows its pieces without letting the browser keep a copy.");
+      reportProgress(total, total, `Displaying ${total} tiles…`);
+      pushLog(`Done: ${width}×${height} display-only (${total} tiles, tainted canvas)`);
+      setCanvasVisible(true);
+      preview.resetTransform(document);
+      controller.dispatch(nextEvent("preflight-display-only", { transport: "display" }) as never);
+      recordWebHistory(url, width, height, "display");
+      update();
+    };
     const queue = [...plan.tiles];
     const tileWorker = async (): Promise<void> => {
       while (queue.length && !failed) {
@@ -1491,35 +1498,36 @@ async function runJob(url: string): Promise<void> {
       // supports it, or uses the extension/desktop app for a clean save.
       // Tiles never use the metadata proxy; the handoff below is plain
       // navigation to a `dezoomify://` link, not a proxied fetch.
-      viewCtx.originClean = false;
-      viewCtx.sourceUrl = url;
-      viewCtx.desktopHandoffUrl = desktopHandoffLink(url);
-      setStep("Displaying the image…", "This site shows its pieces without letting the browser keep a copy.");
-      reportProgress(total, total, `Displaying ${total} tiles…`);
-      pushLog(`Done: ${width}×${height} display-only (${total} tiles, tainted canvas)`);
-      setCanvasVisible(true);
-      preview.resetTransform(document);
-      controller.dispatch(nextEvent("preflight-display-only", { transport: "display" }) as never);
-      recordWebHistory(url, width, height, "display");
-      update();
+      finishDisplayOnly();
       return;
     }
 
     controller.dispatch(nextEvent("save-start") as never);
     setStep("Assembling the final picture…", "Encoding PNG in your browser");
     reportProgress(total, total, "Encoding PNG…");
-    const blob = await new Promise<Blob>((resolve, reject) => {
-      canvas.toBlob(
-        (b) => (b ? resolve(b) : reject(failure(
-          "OUTPUT_ENCODE_FAILED",
-          "The final picture could not be created from the saved pieces.",
-          false,
-          undefined,
-          "canvas.toBlob returned null while encoding the PNG",
-        ))),
-        "image/png",
-      );
-    });
+    let blob: Blob;
+    try {
+      blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob(
+          (b) => (b ? resolve(b) : reject(failure(
+            "OUTPUT_ENCODE_FAILED",
+            "The final picture could not be created from the saved pieces.",
+            false,
+            undefined,
+            "canvas.toBlob returned null while encoding the PNG",
+          ))),
+          "image/png",
+        );
+      });
+    } catch (error) {
+      // A browser may defer origin-clean enforcement until toBlob. Keep the
+      // assembled canvas visible and never retry serialization in that case.
+      if (isCanvasTaintError(error)) {
+        finishDisplayOnly();
+        return;
+      }
+      throw error;
+    }
     if (resultBlobUrl) URL.revokeObjectURL(resultBlobUrl);
     resultBlobUrl = URL.createObjectURL(blob);
     viewCtx.completedInfo = {
@@ -1541,13 +1549,13 @@ async function runJob(url: string): Promise<void> {
     if (token !== jobToken) return;
     queueOutcome = "failed";
     const structured = error as {
-      code?: string;
+      code?: unknown;
       message?: string;
       detail?: string;
       technical?: string;
       retryable?: boolean;
     };
-    const code = structured?.code || "DISCOVERY_FAILED";
+    const code = stableErrorCode(error);
     const message = structured?.message || "Could not save this zoomable image.";
     const detail = structured?.detail ?? structured?.technical;
     // The activity log is technical: prefer the dense chain over UI copy.

--- a/test/controller.test.mjs
+++ b/test/controller.test.mjs
@@ -54,6 +54,20 @@ test("controller display-only branch + failed stores structured error", () => {
   assert.deepEqual(d.getState().error, err);
 });
 
+test("controller can fall back from saving to display-only", () => {
+  const c = createController("s11");
+  let seq = 0;
+  const next = (kind, extra = {}) => ({ seq: ++seq, sessionId: "s11", kind, ...extra });
+  c.dispatch(next("start-discovery"));
+  c.dispatch(next("images-found"));
+  c.dispatch(next("image-chosen"));
+  c.dispatch(next("level-chosen"));
+  c.dispatch(next("preflight-ok"));
+  c.dispatch(next("save-start"));
+  assert.ok(c.dispatch(next("preflight-display-only")));
+  assert.equal(c.getState().status, "display-only");
+});
+
 test("stale seq and foreign session ignored; illegal transition rejected", () => {
   const c = createController("s1");
   assert.ok(c.dispatch({ seq: 1, sessionId: "s1", kind: "start-discovery" }));


### PR DESCRIPTION
## Summary
- prevent browser exception values such as DOMException's numeric code from crashing error classification
- keep tainted canvas jobs on the display-only path instead of attempting PNG serialization
- handle browsers that defer the taint check until canvas encoding
- add regression coverage and regenerate extension mirrors

## Verification
- cargo xtask test web --no-e2e
- cargo xtask check
- pnpm exec tsc --noEmit