### PR TITLE
fix(xtask): bootstrap pnpm and accept newer Node

### DIFF
--- a/crates/xtask/src/check.rs
+++ b/crates/xtask/src/check.rs
@@ -30,11 +30,11 @@ fn run_typecheck() -> Result<(), String> {
         .args(["typecheck"])
         .current_dir(super::repo_root())
         .status()
-        .map_err(|e| format!("failed to run pnpm typecheck: {e}"))?;
+        .map_err(|e| format!("failed to launch pnpm for typecheck: {e}"))?;
     status
         .success()
         .then_some(())
-        .ok_or_else(|| "pnpm typecheck failed".to_string())
+        .ok_or_else(|| "pnpm typecheck failed (run `pnpm typecheck` for details)".to_string())
 }
 
 fn run_cargo(args: &[&str]) -> Result<(), String> {

--- a/crates/xtask/src/desktop.rs
+++ b/crates/xtask/src/desktop.rs
@@ -723,35 +723,148 @@ fn build_frontend() -> Result<(), String> {
     Ok(())
 }
 
-/// Build the pnpm invocation for the desktop frontend.
+/// Build the pnpm invocation for any workspace task.
 ///
-/// On Linux/macOS this is `pnpm` exactly as before. On Windows, Rust's
-/// `Command` (CreateProcess) only resolves `.exe` on PATH, not the
-/// `.cmd` shims a pnpm install leaves behind, so resolve explicitly: a
-/// real `pnpm.exe` runs directly, otherwise the resolved PATHEXT shim runs
-/// via `cmd /c` (batch files need the command interpreter). A truly absent
-/// pnpm fails closed naming the program and the fix.
+/// A `pnpm` already on PATH wins. Otherwise fall back to Corepack, which ships
+/// with Node and runs the version pinned in `package.json`'s
+/// `packageManager` field, so a fresh checkout needs no separate global pnpm
+/// install. On Windows, Rust's `Command` (CreateProcess) only resolves `.exe`
+/// on PATH, not the `.cmd` shims a pnpm/Corepack install leaves behind, so
+/// resolve explicitly: a real `.exe` runs directly, otherwise the resolved
+/// PATHEXT shim runs via `cmd /c`. When neither program exists the caller
+/// fails closed naming both.
 pub(crate) fn pnpm_command() -> Result<Command, String> {
-    if cfg!(windows) {
+    #[cfg(windows)]
+    {
         pnpm_command_windows()
-    } else {
-        Ok(Command::new("pnpm"))
+    }
+    #[cfg(not(windows))]
+    {
+        pnpm_command_unix()
     }
 }
 
+const MISSING_PNPM: &str =
+    "neither pnpm nor corepack is on PATH (Node bundles Corepack; install Node or run `corepack enable`)";
+
+/// Install Corepack's pnpm shim into a repo-local, gitignored directory and
+/// return it. Corepack ships with Node, so a fresh checkout gets the version
+/// pinned in `package.json` without any global pnpm install. The shim lives
+/// under `target/`, so `cargo clean` only makes the next call reinstall it.
+fn corepack_shims() -> Result<std::path::PathBuf, String> {
+    let dir = super::repo_root().join("target").join("corepack-shims");
+    let shim = dir.join(if cfg!(windows) { "pnpm.cmd" } else { "pnpm" });
+    if shim.is_file() {
+        return Ok(dir);
+    }
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        format!(
+            "cannot create corepack shim directory {}: {e}",
+            dir.display()
+        )
+    })?;
+    let status = Command::new("corepack")
+        .args(["enable", "--install-directory"])
+        .arg(&dir)
+        .status()
+        .map_err(|e| format!("cannot run corepack: {e}"))?;
+    if !status.success() || !shim.is_file() {
+        return Err(format!(
+            "corepack could not install pnpm shims under {}; install pnpm globally",
+            dir.display()
+        ));
+    }
+    Ok(dir)
+}
+
+/// `PATH` with `dir` first, so a spawned pnpm and the scripts it recursively
+/// runs both resolve the Corepack shim.
+fn path_with_prepended(dir: &std::path::Path) -> Result<std::ffi::OsString, String> {
+    let old = std::env::var_os("PATH").unwrap_or_default();
+    let paths = std::iter::once(dir.to_path_buf()).chain(std::env::split_paths(&old));
+    std::env::join_paths(paths).map_err(|e| format!("cannot build PATH for pnpm: {e}"))
+}
+
+/// Whether `name` is directly runnable from PATH on this host.
+fn program_available(name: &str) -> bool {
+    #[cfg(unix)]
+    {
+        program_on_path(name)
+    }
+    #[cfg(windows)]
+    {
+        let dirs: Vec<std::path::PathBuf> = std::env::var_os("PATH")
+            .map(|path| std::env::split_paths(&path).collect())
+            .unwrap_or_default();
+        let pathext =
+            std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+        resolve_windows_program(name, &dirs, &pathext).is_some()
+    }
+}
+
+/// PATH for a child that may shell out to `pnpm` (for example the desktop dev
+/// smoke test). `None` keeps the inherited environment when a runnable pnpm
+/// already exists or Corepack is unavailable.
+fn node_path() -> Result<Option<std::ffi::OsString>, String> {
+    if program_available("pnpm") || !program_available("corepack") {
+        return Ok(None);
+    }
+    let shims = corepack_shims()?;
+    Ok(Some(path_with_prepended(&shims)?))
+}
+
+#[cfg(unix)]
+fn pnpm_command_unix() -> Result<Command, String> {
+    if program_on_path("pnpm") {
+        return Ok(Command::new("pnpm"));
+    }
+    if !program_on_path("corepack") {
+        return Err(MISSING_PNPM.to_string());
+    }
+    let shims = corepack_shims()?;
+    let mut cmd = Command::new(shims.join("pnpm"));
+    cmd.env("PATH", path_with_prepended(&shims)?);
+    Ok(cmd)
+}
+
+#[cfg(unix)]
+fn program_on_path(name: &str) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::env::var_os("PATH").is_some_and(|path| {
+        std::env::split_paths(&path).any(|dir| {
+            std::fs::metadata(dir.join(name))
+                .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        })
+    })
+}
+
+#[cfg(windows)]
 fn pnpm_command_windows() -> Result<Command, String> {
     let dirs: Vec<std::path::PathBuf> = std::env::var_os("PATH")
         .map(|path| std::env::split_paths(&path).collect())
         .unwrap_or_default();
     let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
-    match resolve_windows_program("pnpm", &dirs, &pathext) {
-        Some((exe, false)) => Ok(Command::new(exe)),
-        Some((shim, true)) => {
-            let mut cmd = Command::new("cmd");
-            cmd.arg("/c").arg(shim);
-            Ok(cmd)
-        }
-        None => Err("pnpm not found on PATH (install the pnpm version pinned in the packageManager field of package.json and ensure it is on PATH)".to_string()),
+    if let Some((program, needs_shell)) = resolve_windows_program("pnpm", &dirs, &pathext) {
+        return Ok(windows_launch(program, needs_shell));
+    }
+    if resolve_windows_program("corepack", &dirs, &pathext).is_some() {
+        let shims = corepack_shims()?;
+        let mut cmd = Command::new("cmd");
+        cmd.arg("/c").arg(shims.join("pnpm.cmd"));
+        cmd.env("PATH", path_with_prepended(&shims)?);
+        return Ok(cmd);
+    }
+    Err(MISSING_PNPM.to_string())
+}
+
+#[cfg(windows)]
+fn windows_launch(program: std::path::PathBuf, needs_shell: bool) -> Command {
+    if needs_shell {
+        let mut cmd = Command::new("cmd");
+        cmd.arg("/c").arg(program);
+        cmd
+    } else {
+        Command::new(program)
     }
 }
 
@@ -762,6 +875,7 @@ fn pnpm_command_windows() -> Result<Command, String> {
 /// directory so a directly-runnable binary is never routed through a
 /// shell. Extension case follows the `pathext` entry as written; the
 /// Windows filesystem matches it case-insensitively.
+#[cfg(any(windows, test))]
 fn resolve_windows_program(
     stem: &str,
     dirs: &[std::path::PathBuf],
@@ -867,6 +981,9 @@ fn run_node_with_deadline(
         .args(args)
         .envs(env.iter().copied())
         .current_dir(super::repo_root());
+    if let Some(path) = node_path()? {
+        command.env("PATH", path);
+    }
     configure_owned_process_tree(&mut command);
     let mut child = command
         .spawn()
@@ -1003,11 +1120,10 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(windows))]
-    fn pnpm_command_unix_is_bare_pnpm() {
-        // Linux/macOS behavior stays byte-identical: a bare `pnpm` lookup.
-        let cmd = super::pnpm_command().expect("pnpm command builds");
-        assert_eq!(cmd.get_program(), "pnpm");
+    fn path_with_prepended_puts_dir_first() {
+        let dir = std::env::temp_dir().join("dezoomify-path-prepend");
+        let joined = super::path_with_prepended(&dir).expect("join PATH");
+        assert_eq!(std::env::split_paths(&joined).next(), Some(dir));
     }
 
     #[test]

--- a/crates/xtask/src/setup.rs
+++ b/crates/xtask/src/setup.rs
@@ -58,13 +58,13 @@ fn configure_git_hooks() -> Result<(), String> {
     }
 }
 
-/// Verify `node --version` matches the major pinned in `.node-version`.
+/// Verify `node --version` meets the minimum major pinned in `.node-version`.
 fn check_node() -> Result<(), String> {
     let pin_path = super::repo_root().join(".node-version");
     let pin = std::fs::read_to_string(&pin_path)
         .map_err(|e| {
             format!(
-                "cannot read {}: {e} (restore the pinned Node major, e.g. `22`)",
+                "cannot read {}: {e} (restore the minimum Node major, e.g. `22`)",
                 pin_path.display()
             )
         })?
@@ -72,23 +72,22 @@ fn check_node() -> Result<(), String> {
         .to_string();
     if pin.is_empty() {
         return Err(
-            ".node-version is empty (expected the pinned Node major, e.g. `22`)".to_string(),
+            ".node-version is empty (expected the minimum Node major, e.g. `22`)".to_string(),
         );
     }
-    println!("node pin (.node-version): {pin}");
-    let node = version_of("node", &["--version"]).map_err(|e| {
-        format!("{e} (install Node {pin} so `node --version` works, e.g. `nvm install {pin}`)")
-    })?;
+    println!("node minimum (.node-version): {pin}");
+    let node = version_of("node", &["--version"])
+        .map_err(|e| format!("{e} (install Node {pin} or newer so `node --version` works)"))?;
     println!("node: {node}");
-    let expected = node_major(&pin).ok_or_else(|| {
+    let minimum = node_major(&pin).ok_or_else(|| {
         format!("cannot parse Node major from .node-version pin `{pin}` (expected e.g. `22`)")
     })?;
     let found = node_major(&node).ok_or_else(|| {
-        format!("cannot parse `node --version` output `{node}` (reinstall Node {expected})")
+        format!("cannot parse `node --version` output `{node}` (install Node {minimum} or newer)")
     })?;
-    if expected != found {
+    if found < minimum {
         return Err(format!(
-            "node major version mismatch: .node-version expects major {expected} (pin `{pin}`), found `{node}`. Install Node {expected} (e.g. `nvm install {expected}` / `fnm install {expected}`) and ensure `node --version` reports v{expected}."
+            "node version too old: .node-version requires >={minimum} (pin `{pin}`), found `{node}`. Install Node {minimum} or newer and ensure `node --version` reports v{minimum} or above."
         ));
     }
     Ok(())
@@ -118,7 +117,7 @@ fn check_pnpm() -> Result<(), String> {
         .arg("--version")
         .current_dir(&root)
         .output()
-        .map_err(|e| format!("cannot run pnpm: {e}"))?;
+        .map_err(|e| format!("failed to launch pnpm: {e}"))?;
     if !output.status.success() {
         return Err(format!("pnpm --version failed; install pnpm {expected}"));
     }
@@ -292,14 +291,13 @@ fn report_playwright_browsers() {
 
 /// Extract the leading numeric major from a version string such as `22`,
 /// `22.12.0`, `v22.12.0`, or `22.x`.
-fn node_major(version: &str) -> Option<String> {
+fn node_major(version: &str) -> Option<u64> {
     let stripped = version.trim().strip_prefix('v').unwrap_or(version.trim());
     let major = stripped.split(['.', 'x', 'X']).next()?.trim();
-    if major.chars().all(|c| c.is_ascii_digit()) && !major.is_empty() {
-        Some(major.to_string())
-    } else {
-        None
+    if major.is_empty() || !major.chars().all(|c| c.is_ascii_digit()) {
+        return None;
     }
+    major.parse::<u64>().ok()
 }
 
 fn version_of(cmd: &str, args: &[&str]) -> Result<String, String> {
@@ -311,4 +309,26 @@ fn version_of(cmd: &str, args: &[&str]) -> Result<String, String> {
         return Err(format!("{cmd} failed"));
     }
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn node_major_parses_pinned_and_runtime_forms() {
+        assert_eq!(super::node_major("22"), Some(22));
+        assert_eq!(super::node_major("v22.12.0"), Some(22));
+        assert_eq!(super::node_major("26.8.2"), Some(26));
+        assert_eq!(super::node_major("22.x"), Some(22));
+        assert!(super::node_major("").is_none());
+        assert!(super::node_major("abc").is_none());
+    }
+
+    #[test]
+    fn node_minimum_allows_newer_majors() {
+        let minimum = super::node_major("22").expect("parse pin");
+        let newer = super::node_major("v26.8.2").expect("parse runtime");
+        let older = super::node_major("v20.19.0").expect("parse runtime");
+        assert!(newer >= minimum);
+        assert!(older < minimum);
+    }
 }

--- a/crates/xtask/src/test_cmd.rs
+++ b/crates/xtask/src/test_cmd.rs
@@ -94,13 +94,17 @@ fn run_step(
     summary: &mut Vec<(&'static str, bool)>,
     step: impl FnOnce() -> Result<(), String>,
 ) -> Result<(), String> {
-    let ok = step().is_ok();
-    summary.push((name, ok));
-    if !ok {
-        print_summary(summary);
-        return Err(format!("test step '{name}' failed"));
+    match step() {
+        Ok(()) => {
+            summary.push((name, true));
+            Ok(())
+        }
+        Err(reason) => {
+            summary.push((name, false));
+            print_summary(summary);
+            Err(format!("test step '{name}' failed: {reason}"))
+        }
     }
-    Ok(())
 }
 
 fn cargo_test() -> Result<(), String> {

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,8 +35,9 @@ cargo xtask build web
 cargo xtask dev web
 ```
 
-`setup` verifies the pinned Rust, Node, pnpm, WASM, and wasm-bindgen tools,
-installs the frozen pnpm workspace dependencies, and reports browser status.
+`setup` verifies the pinned Rust, pnpm, WASM, and wasm-bindgen tools plus the
+minimum Node version from `.node-version`, installs the frozen pnpm workspace
+dependencies, and reports browser status.
 It never installs browser binaries or Rust toolchains. `check` runs formatting,
 lint, type checking, dependency boundaries, generated-file checks, and manifest
 validation without rewriting source files.


### PR DESCRIPTION
## Problem

A fresh checkout failed the dev tasks with a hidden, misleading error:

```
$ cargo xtask test
test summary:
  check: FAIL
error: test step 'check' failed
```

Running `cargo xtask check` directly revealed `failed to run pnpm typecheck: No such file or directory`. Digging further:

- `setup` rejected Node 26 because `.node-version` (`22`) was treated as an exact pin.
- `pnpm` was not on `PATH`, so every pnpm-backed lane needed a manual global install first.
- The aggregate `test` runner discarded the failing step's `Err` reason, printing only `check: FAIL`.

## Changes

- **Node minimum, not pin**: `.node-version` is now a minimum major; newer majors pass. Parsing returns `u64` for comparison, with unit tests.
- **Visible failures**: `test_cmd::run_step` keeps the inner error, so failures read `test step 'check' failed: <reason>`.
- **pnpm bootstrap**: when no global `pnpm` is on `PATH`, `pnpm_command` installs Corepack's pinned pnpm into the gitignored `target/corepack-shims` and prepends it to the spawned process `PATH`. This means `cargo xtask setup` sets itself up, and recursive `pnpm` calls inside scripts resolve. Windows keeps its `.exe`/`cmd /c` resolution path.
- **Node children**: desktop node suites (e.g. `dev-smoke.test.mjs`, which spawns `pnpm`) also get the shim on `PATH`.
- **Accurate errors**: launch failures report the underlying error instead of asserting pnpm is missing.
- **Docs**: `docs/development.md` describes `.node-version` as a minimum without hardcoding a version.

## Testing

```
cargo xtask check
cargo xtask setup
cargo xtask test
```

All pass on a checkout with Node 26 and no global pnpm.