### PR TITLE
fix(ui): trim display-only result copy

### DIFF
--- a/apps/extension/src/vendor/view.js
+++ b/apps/extension/src/vendor/view.js
@@ -5,8 +5,6 @@
 // Modern accessible Shared UI view renderer.
 // Binds host-neutral DOM components to the shared controller and app integration.
 
-import { renderAppChoice } from "./controller.js";
-
 import { t } from "./i18n.js";
 import {
   renderSaveGuidance,
@@ -1086,48 +1084,16 @@ function mountDisplayOnlySection(
     </div>
   `;
 
-  if (ctx?.capabilities) {
-    const appChoice = renderAppChoice(ctx.capabilities);
-    const guidanceBox = parent.ownerDocument.createElement("p");
-    guidanceBox.className = "dz-notice-guidance";
-    guidanceBox.textContent = appChoice;
-    section.appendChild(guidanceBox);
-  }
-
   // Display-only handoff (todo 6.2, one-click in 5.5): the assembled canvas
   // stays visible below without a programmatic save (cross-origin canvas,
   // right-click where supported). Offer the readable routes explicitly
   // instead of failing late with TILE_FAILED: extension guidance plus the
-  // desktop `dezoomify://` handoff when the host supplied one. The summary
-  // names origin/scope/recipient/job memory-only (extension consent pattern);
-  // the desktop app confirms again before any effect.
+  // desktop `dezoomify://` handoff when the host supplied one. The desktop
+  // app confirms again before any effect.
   const handoffUrl = typeof ctx?.desktopHandoffUrl === "string" ? ctx.desktopHandoffUrl : "";
   const handoffSource = typeof ctx?.sourceUrl === "string" ? ctx.sourceUrl : "";
   const handoffOrigin = handoffOriginFor(handoffUrl, handoffSource);
   const handoffLabel = handoffOrigin !== "" ? `Send to desktop app (${handoffOrigin})` : "Send to desktop app";
-  const shownNote = parent.ownerDocument.createElement("p");
-  shownNote.className = "dz-notice-message";
-  if (handoffUrl !== "") {
-    shownNote.innerHTML = `Shown below without saving. <a id="dz-display-handoff-inline" href="${escapeHtml(handoffUrl)}">Open in desktop app</a>`;
-    shownNote.querySelector("#dz-display-handoff-inline")?.addEventListener("click", () => {
-      try {
-        callbacks.onOpenExternalLink?.(handoffUrl);
-      } catch {
-        // Handoff navigation must never break display.
-      }
-    });
-  } else {
-    shownNote.textContent = "Shown below without saving.";
-  }
-  section.appendChild(shownNote);
-
-  if (handoffUrl !== "" && handoffOrigin !== "") {
-    const consent = parent.ownerDocument.createElement("p");
-    consent.className = "dz-notice-message";
-    consent.id = "dz-handoff-consent";
-    consent.textContent = `Sends ${handoffOrigin} to the desktop app. No sign-in details travel; one job only, kept in memory.`;
-    section.appendChild(consent);
-  }
 
   const guide = parent.ownerDocument.createElement("div");
   guide.className = "dz-guidance-section";

--- a/packages/shared-ui/src/view.ts
+++ b/packages/shared-ui/src/view.ts
@@ -2,7 +2,6 @@
 // Binds host-neutral DOM components to the shared controller and app integration.
 
 import type { ControllerState, StructuredError, AppCapabilities } from "./controller.ts";
-import { renderAppChoice } from "./controller.ts";
 import type { HistoryEntry } from "./history.ts";
 import { t } from "./i18n.ts";
 import {
@@ -1241,48 +1240,16 @@ function mountDisplayOnlySection(
     </div>
   `;
 
-  if (ctx?.capabilities) {
-    const appChoice = renderAppChoice(ctx.capabilities);
-    const guidanceBox = parent.ownerDocument.createElement("p");
-    guidanceBox.className = "dz-notice-guidance";
-    guidanceBox.textContent = appChoice;
-    section.appendChild(guidanceBox);
-  }
-
   // Display-only handoff (todo 6.2, one-click in 5.5): the assembled canvas
   // stays visible below without a programmatic save (cross-origin canvas,
   // right-click where supported). Offer the readable routes explicitly
   // instead of failing late with TILE_FAILED: extension guidance plus the
-  // desktop `dezoomify://` handoff when the host supplied one. The summary
-  // names origin/scope/recipient/job memory-only (extension consent pattern);
-  // the desktop app confirms again before any effect.
+  // desktop `dezoomify://` handoff when the host supplied one. The desktop
+  // app confirms again before any effect.
   const handoffUrl = typeof ctx?.desktopHandoffUrl === "string" ? ctx.desktopHandoffUrl : "";
   const handoffSource = typeof ctx?.sourceUrl === "string" ? ctx.sourceUrl : "";
   const handoffOrigin = handoffOriginFor(handoffUrl, handoffSource);
   const handoffLabel = handoffOrigin !== "" ? `Send to desktop app (${handoffOrigin})` : "Send to desktop app";
-  const shownNote = parent.ownerDocument.createElement("p");
-  shownNote.className = "dz-notice-message";
-  if (handoffUrl !== "") {
-    shownNote.innerHTML = `Shown below without saving. <a id="dz-display-handoff-inline" href="${escapeHtml(handoffUrl)}">Open in desktop app</a>`;
-    shownNote.querySelector("#dz-display-handoff-inline")?.addEventListener("click", () => {
-      try {
-        callbacks.onOpenExternalLink?.(handoffUrl);
-      } catch {
-        // Handoff navigation must never break display.
-      }
-    });
-  } else {
-    shownNote.textContent = "Shown below without saving.";
-  }
-  section.appendChild(shownNote);
-
-  if (handoffUrl !== "" && handoffOrigin !== "") {
-    const consent = parent.ownerDocument.createElement("p");
-    consent.className = "dz-notice-message";
-    consent.id = "dz-handoff-consent";
-    consent.textContent = `Sends ${handoffOrigin} to the desktop app. No sign-in details travel; one job only, kept in memory.`;
-    section.appendChild(consent);
-  }
 
   const guide = parent.ownerDocument.createElement("div");
   guide.className = "dz-guidance-section";


### PR DESCRIPTION
## Summary
- Remove the "Best next step / What each choice can do" app-choice guidance from the display-only ("Image downloaded") view.
- Remove the "Shown below without saving. Open in desktop app" note and its inline desktop link.
- Remove the "Sends <origin> to the desktop app..." consent summary from the display-only view.
- Keep the "Send to desktop app" action and the "Ways to save this artwork" guidance cards.

The failed/error view still carries its own handoff consent copy.

## Test plan
- [x] `node --test test/*.test.mjs` (146 pass)
- [x] `cargo xtask test ui`
- [x] `pnpm typecheck` / `tsc --noEmit`
- [x] `node scripts/sync-web-js.mjs --check` (vendor mirror regenerated)