### PR TITLE
feat(ui): use a single landing title

### DIFF
--- a/apps/desktop/src/desktop.css
+++ b/apps/desktop/src/desktop.css
@@ -90,10 +90,6 @@ body {
   margin-bottom: 1.75rem;
 }
 
-#root .dz-description h1 {
-  font-size: clamp(2rem, 4.3vw, 3.65rem);
-}
-
 #root .dz-form {
   padding: 0.55rem;
   border: 1px solid var(--dz-surface-border);

--- a/apps/extension/src/vendor/i18n.js
+++ b/apps/extension/src/vendor/i18n.js
@@ -321,10 +321,8 @@ const en = {
   "view.history.open": "Open again",
   "view.history.clear": "Clear history",
   "view.history.dims": "{w} by {h} pixels",
-  "view.input.eyebrow": "New image",
-  "view.input.title": "Save the full-resolution image",
   "view.input.description":
-    "Paste a viewer page, manifest, or tile address. Dezoomify finds the image and selects the best available resolution.",
+    "Dezoomify downloads zoomable tiled images from libraries, museums, galleries, and other websites. Paste the URL of an image below to download it.",
   "view.input.placeholder": "Paste an image viewer or manifest URL",
   "view.input.aria": "Address of the webpage containing your zoomable image",
   "view.input.start": "Find image",

--- a/apps/extension/src/vendor/locales/de.js
+++ b/apps/extension/src/vendor/locales/de.js
@@ -220,10 +220,8 @@ export const de = {
   "view.history.open": "Erneut offnen",
   "view.history.clear": "Verlauf loschen",
   "view.history.dims": "{w} mal {h} Pixel",
-  "view.input.eyebrow": "Zoombare Bilder speichern",
-  "view.input.title": "Dezoomify",
   "view.input.description":
-    "Dezoomify speichert zoombare Bilder. Fuegen Sie unten die URL eines Bildbetrachters, Manifests oder einer Kachel-Adresse ein. Dezoomify findet das Bild und speichert die hoechste Aufloesung, die in Ihren Browser passt. Wenn es fertig ist, speichern Sie das Bild mit der Schaltflaeche auf Ihrem Computer.",
+    "Dezoomify laedt zoombare Kachelbilder aus Bibliotheken, Museen, Galerien und anderen Websites herunter. Fuegen Sie unten die Adresse eines Bildes ein, um es herunterzuladen.",
   "view.input.placeholder": "Adresse eines Bildbetrachters oder Manifests einfuegen",
   "view.input.aria": "Adresse der Webseite mit dem zoombaren Bild",
   "view.input.start": "Bild finden",

--- a/apps/extension/src/vendor/locales/fr.js
+++ b/apps/extension/src/vendor/locales/fr.js
@@ -220,10 +220,8 @@ export const fr = {
   "view.history.open": "Rouvrir",
   "view.history.clear": "Effacer l historique",
   "view.history.dims": "{w} par {h} pixels",
-  "view.input.eyebrow": "Enregistreur d images zoomables",
-  "view.input.title": "Dezoomify",
   "view.input.description":
-    "Dezoomify permet d enregistrer des images zoomables. Collez ci-dessous l adresse d une visionneuse, d un manifeste ou d une tuile. Dezoomify trouve l image et enregistre la resolution la plus elevee qui tient dans votre navigateur. Lorsqu elle est prete, utilisez le bouton Enregistrer l image pour la conserver sur votre ordinateur.",
+    "Dezoomify télécharge des images zoomables en tuiles depuis des bibliothèques, des musées, des galeries et d’autres sites web. Collez ci-dessous l’adresse d’une image pour la télécharger.",
   "view.input.placeholder": "Collez l adresse d une visionneuse ou d un manifeste",
   "view.input.aria": "Adresse de la page contenant votre image zoomable",
   "view.input.start": "Trouver l image",

--- a/apps/extension/src/vendor/locales/it.js
+++ b/apps/extension/src/vendor/locales/it.js
@@ -220,10 +220,8 @@ export const it = {
   "view.history.open": "Riapri",
   "view.history.clear": "Cancella la cronologia",
   "view.history.dims": "{w} per {h} pixel",
-  "view.input.eyebrow": "Salvataggio di immagini zoomabili",
-  "view.input.title": "Dezoomify",
   "view.input.description":
-    "Dezoomify permette di salvare immagini zoomabili. Incolla qui sotto l URL di un visualizzatore, manifesto o indirizzo di tasselli. Dezoomify trova l immagine e salva la risoluzione piu alta adatta al browser. Quando e pronta, usa il pulsante Salva immagine per salvarla sul tuo computer.",
+    "Dezoomify scarica immagini zoomabili a tasselli da biblioteche, musei, gallerie e altri siti web. Incolla qui sotto l indirizzo di un immagine per scaricarla.",
   "view.input.placeholder": "Incolla l indirizzo di un visualizzatore o manifesto",
   "view.input.aria": "Indirizzo della pagina con l immagine ingrandibile",
   "view.input.start": "Trova immagine",

--- a/apps/extension/src/vendor/theme.css
+++ b/apps/extension/src/vendor/theme.css
@@ -345,6 +345,7 @@ abbr[title] {
   display: inline-flex;
   align-items: center;
   gap: 0.65rem;
+  margin: 0;
   color: var(--dz-text-secondary);
   font-size: 0.92rem;
   font-weight: 700;
@@ -381,24 +382,7 @@ abbr[title] {
   margin: 0 0 1.6rem;
 }
 
-.dz-description h1 {
-  margin: 0.3rem 0 0.75rem;
-  color: var(--dz-text-primary);
-  font-size: clamp(1.85rem, 4vw, 3rem);
-  font-weight: 720;
-  letter-spacing: -0.045em;
-  line-height: 1.08;
-}
-
 .dz-description p { margin: 0; }
-
-.dz-eyebrow {
-  color: var(--dz-link-color);
-  font-size: 0.75rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
 
 .dz-description strong {
   font-weight: 700;

--- a/apps/extension/src/vendor/view.js
+++ b/apps/extension/src/vendor/view.js
@@ -425,10 +425,10 @@ export function renderView(
     header = container.ownerDocument.createElement("div");
     header.className = "dz-header";
     header.innerHTML = `
-      <div class="dz-product-mark" aria-label="Dezoomify">
+      <h1 class="dz-product-mark">
         ${getDezoomifyLogoSvg(30)}
         <span>Dezoomify</span>
-      </div>
+      </h1>
     `;
     card.prepend(header);
   }
@@ -711,8 +711,6 @@ function mountInputSection(
   const desc = parent.ownerDocument.createElement("div");
   desc.className = "dz-description";
   desc.innerHTML = `
-    <p class="dz-eyebrow">${escapeHtml(t("view.input.eyebrow"))}</p>
-    <h1>${escapeHtml(t("view.input.title"))}</h1>
     <p>${escapeHtml(t("view.input.description"))}</p>
   `;
   body.appendChild(desc);

--- a/packages/shared-ui/src/i18n.ts
+++ b/packages/shared-ui/src/i18n.ts
@@ -321,10 +321,8 @@ const en = {
   "view.history.open": "Open again",
   "view.history.clear": "Clear history",
   "view.history.dims": "{w} by {h} pixels",
-  "view.input.eyebrow": "New image",
-  "view.input.title": "Save the full-resolution image",
   "view.input.description":
-    "Paste a viewer page, manifest, or tile address. Dezoomify finds the image and selects the best available resolution.",
+    "Dezoomify downloads zoomable tiled images from libraries, museums, galleries, and other websites. Paste the URL of an image below to download it.",
   "view.input.placeholder": "Paste an image viewer or manifest URL",
   "view.input.aria": "Address of the webpage containing your zoomable image",
   "view.input.start": "Find image",

--- a/packages/shared-ui/src/locales/de.ts
+++ b/packages/shared-ui/src/locales/de.ts
@@ -216,10 +216,8 @@ export const de = {
   "view.history.open": "Erneut offnen",
   "view.history.clear": "Verlauf loschen",
   "view.history.dims": "{w} mal {h} Pixel",
-  "view.input.eyebrow": "Zoombare Bilder speichern",
-  "view.input.title": "Dezoomify",
   "view.input.description":
-    "Dezoomify speichert zoombare Bilder. Fuegen Sie unten die URL eines Bildbetrachters, Manifests oder einer Kachel-Adresse ein. Dezoomify findet das Bild und speichert die hoechste Aufloesung, die in Ihren Browser passt. Wenn es fertig ist, speichern Sie das Bild mit der Schaltflaeche auf Ihrem Computer.",
+    "Dezoomify laedt zoombare Kachelbilder aus Bibliotheken, Museen, Galerien und anderen Websites herunter. Fuegen Sie unten die Adresse eines Bildes ein, um es herunterzuladen.",
   "view.input.placeholder": "Adresse eines Bildbetrachters oder Manifests einfuegen",
   "view.input.aria": "Adresse der Webseite mit dem zoombaren Bild",
   "view.input.start": "Bild finden",

--- a/packages/shared-ui/src/locales/fr.ts
+++ b/packages/shared-ui/src/locales/fr.ts
@@ -216,10 +216,8 @@ export const fr = {
   "view.history.open": "Rouvrir",
   "view.history.clear": "Effacer l historique",
   "view.history.dims": "{w} par {h} pixels",
-  "view.input.eyebrow": "Enregistreur d images zoomables",
-  "view.input.title": "Dezoomify",
   "view.input.description":
-    "Dezoomify permet d enregistrer des images zoomables. Collez ci-dessous l adresse d une visionneuse, d un manifeste ou d une tuile. Dezoomify trouve l image et enregistre la resolution la plus elevee qui tient dans votre navigateur. Lorsqu elle est prete, utilisez le bouton Enregistrer l image pour la conserver sur votre ordinateur.",
+    "Dezoomify télécharge des images zoomables en tuiles depuis des bibliothèques, des musées, des galeries et d’autres sites web. Collez ci-dessous l’adresse d’une image pour la télécharger.",
   "view.input.placeholder": "Collez l adresse d une visionneuse ou d un manifeste",
   "view.input.aria": "Adresse de la page contenant votre image zoomable",
   "view.input.start": "Trouver l image",

--- a/packages/shared-ui/src/locales/it.ts
+++ b/packages/shared-ui/src/locales/it.ts
@@ -216,10 +216,8 @@ export const it = {
   "view.history.open": "Riapri",
   "view.history.clear": "Cancella la cronologia",
   "view.history.dims": "{w} per {h} pixel",
-  "view.input.eyebrow": "Salvataggio di immagini zoomabili",
-  "view.input.title": "Dezoomify",
   "view.input.description":
-    "Dezoomify permette di salvare immagini zoomabili. Incolla qui sotto l URL di un visualizzatore, manifesto o indirizzo di tasselli. Dezoomify trova l immagine e salva la risoluzione piu alta adatta al browser. Quando e pronta, usa il pulsante Salva immagine per salvarla sul tuo computer.",
+    "Dezoomify scarica immagini zoomabili a tasselli da biblioteche, musei, gallerie e altri siti web. Incolla qui sotto l indirizzo di un immagine per scaricarla.",
   "view.input.placeholder": "Incolla l indirizzo di un visualizzatore o manifesto",
   "view.input.aria": "Indirizzo della pagina con l immagine ingrandibile",
   "view.input.start": "Trova immagine",

--- a/packages/shared-ui/src/styles/theme.css
+++ b/packages/shared-ui/src/styles/theme.css
@@ -345,6 +345,7 @@ abbr[title] {
   display: inline-flex;
   align-items: center;
   gap: 0.65rem;
+  margin: 0;
   color: var(--dz-text-secondary);
   font-size: 0.92rem;
   font-weight: 700;
@@ -381,24 +382,7 @@ abbr[title] {
   margin: 0 0 1.6rem;
 }
 
-.dz-description h1 {
-  margin: 0.3rem 0 0.75rem;
-  color: var(--dz-text-primary);
-  font-size: clamp(1.85rem, 4vw, 3rem);
-  font-weight: 720;
-  letter-spacing: -0.045em;
-  line-height: 1.08;
-}
-
 .dz-description p { margin: 0; }
-
-.dz-eyebrow {
-  color: var(--dz-link-color);
-  font-size: 0.75rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
 
 .dz-description strong {
   font-weight: 700;

--- a/packages/shared-ui/src/view.ts
+++ b/packages/shared-ui/src/view.ts
@@ -580,10 +580,10 @@ export function renderView(
     header = container.ownerDocument.createElement("div");
     header.className = "dz-header";
     header.innerHTML = `
-      <div class="dz-product-mark" aria-label="Dezoomify">
+      <h1 class="dz-product-mark">
         ${getDezoomifyLogoSvg(30)}
         <span>Dezoomify</span>
-      </div>
+      </h1>
     `;
     card.prepend(header);
   }
@@ -866,8 +866,6 @@ function mountInputSection(
   const desc = parent.ownerDocument.createElement("div");
   desc.className = "dz-description";
   desc.innerHTML = `
-    <p class="dz-eyebrow">${escapeHtml(t("view.input.eyebrow"))}</p>
-    <h1>${escapeHtml(t("view.input.title"))}</h1>
     <p>${escapeHtml(t("view.input.description"))}</p>
   `;
   body.appendChild(desc);


### PR DESCRIPTION
## Summary
- Render the "Dezoomify" brand mark as the idle view `<h1>` and remove the "New image" eyebrow and the separate "Save the full-resolution image" heading, so the landing view shows one title and one description line.
- Update `view.input.description` across English, French, German, and Italian, and remove the now-unused `view.input.eyebrow` and `view.input.title` keys.
- Regenerate the extension vendor mirrors and drop the dead eyebrow / description-`h1` CSS.

## Test plan
- `cargo xtask check`
- `cargo xtask test`
- `node scripts/sync-web-js.mjs --check`