### PR TITLE
chore: use stable Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.98.0"
+channel = "stable"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Replace the exact Rust 1.98.0 pin with the stable channel while keeping the required components and WASM target.\n\nValidation: cargo xtask check