### PR TITLE
Add Second Canvas format support

### DIFF
--- a/crates/dezoomify-core/src/core/registry.rs
+++ b/crates/dezoomify-core/src/core/registry.rs
@@ -3,7 +3,7 @@
 use super::discovery::{DezoomerSpec, DiscoveryLimits, DiscoveryOperation};
 use crate::{
     arcgis, bulk_text, custom_yaml, dzi, fsi, generic, google_arts_and_culture, hungaricana, iiif,
-    iipimage, krpano, lizardtech, pnav, topviewer, vls, wmts, xlimage, zoomify,
+    iipimage, krpano, lizardtech, pnav, second_canvas, topviewer, vls, wmts, xlimage, zoomify,
 };
 
 /// Every built-in dezoomer, in candidate priority order.
@@ -13,6 +13,7 @@ const BUILTINS: &[DezoomerSpec] = &[
     zoomify::SPEC,
     iiif::SPEC,
     dzi::SPEC,
+    second_canvas::SPEC,
     generic::SPEC,
     krpano::SPEC,
     iipimage::SPEC,
@@ -172,6 +173,7 @@ mod tests {
                 ("zoomify", "Zoomify"),
                 ("iiif", "IIIF"),
                 ("deepzoom", "Seadragon (Deep Zoom Image)"),
+                ("second_canvas", "Second Canvas"),
                 ("generic", "Generic dezoomer"),
                 ("krpano", "krpano"),
                 ("iipimage", "IIPImage"),

--- a/crates/dezoomify-core/src/lib.rs
+++ b/crates/dezoomify-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod iipimage;
 pub mod krpano;
 pub mod lizardtech;
 pub mod pnav;
+pub mod second_canvas;
 pub mod topviewer;
 pub mod vec2d;
 pub mod vls;

--- a/crates/dezoomify-core/src/second_canvas/mod.rs
+++ b/crates/dezoomify-core/src/second_canvas/mod.rs
@@ -1,7 +1,8 @@
 //! Pure discovery for Second Canvas (Madpixel) `gigapixel` JSON metadata.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
+use regex::bytes::Regex as BytesRegex;
 use serde::{Deserialize, de::IntoDeserializer};
 use url::Url;
 
@@ -9,12 +10,14 @@ use crate::Vec2d;
 use crate::core::{
     CatalogEntry, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryMatch,
     DiscoveryResource, DiscoveryRoute, DiscoveryStep, Grid, ImageCatalog, ImageDescriptor,
-    LevelDescriptor, Request, StableId,
+    LevelDescriptor, Positioned, PositionedTile, ProcessingRecipe, Request, StableId,
+    TileSourceError, resolve_relative,
 };
 
 const ROUTES: &[DiscoveryRoute] = &[
     DiscoveryMatch::ContentPredicate(contains_gigapixel).extract(catalog),
     DiscoveryMatch::ContentPredicate(contains_viewer_script).then(follow_viewer_config),
+    DiscoveryMatch::ContentPredicate(contains_second_canvas_iframe).then(follow_iframe),
 ];
 
 pub const SPEC: DezoomerSpec =
@@ -32,24 +35,64 @@ fn contains_viewer_script(bytes: &[u8]) -> bool {
     page.contains("scw.min.js") || page.contains("scv.min.js")
 }
 
+static SECOND_CANVAS_IFRAME_RE: LazyLock<BytesRegex> = LazyLock::new(|| {
+    BytesRegex::new(
+        r#"(?is)<iframe\b[^>]*\bsrc\s*=\s*[\"'](?P<src>https?://[^\"']+\.s3\.amazonaws\.com/web/[^\"']+\.html(?:[?#][^\"']*)?)[\"']"#,
+    )
+    .expect("constant Second Canvas iframe pattern")
+});
+
+static EMBEDDED_CONFIG_RE: LazyLock<BytesRegex> = LazyLock::new(|| {
+    BytesRegex::new(
+        r#"(?is)\bsc[wv]\s*\.\s*load\s*\(\s*\{\s*[\"']hash[\"']\s*:\s*[\"'](?P<config>[^\"']+\.json)[\"']"#,
+    )
+    .expect("constant Second Canvas embedded configuration pattern")
+});
+
+fn contains_second_canvas_iframe(bytes: &[u8]) -> bool {
+    SECOND_CANVAS_IFRAME_RE.is_match(bytes)
+}
+
 fn follow_viewer_config(
     _: &DiscoveryContext<'_>,
     resource: DiscoveryResource<'_>,
 ) -> Result<DiscoveryStep, DiscoveryError> {
     Ok(DiscoveryStep::Follow(Request::new(viewer_config_uri(
         resource.final_uri(),
+        resource.bytes(),
     )?)))
 }
 
-fn viewer_config_uri(viewer_uri: &str) -> Result<String, DiscoveryError> {
+fn follow_iframe(
+    _: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    let src = SECOND_CANVAS_IFRAME_RE
+        .captures(resource.bytes())
+        .and_then(|captures| captures.name("src"))
+        .map(|src| String::from_utf8_lossy(src.as_bytes()).replace("&amp;", "&"))
+        .ok_or_else(|| DiscoveryError::Session("Second Canvas iframe has no source".into()))?;
+    Ok(DiscoveryStep::Follow(Request::new(resolve_relative(
+        resource.final_uri(),
+        &src,
+    ))))
+}
+
+fn viewer_config_uri(viewer_uri: &str, viewer_bytes: &[u8]) -> Result<String, DiscoveryError> {
     let viewer = Url::parse(viewer_uri).map_err(|error| {
         DiscoveryError::Session(format!("invalid Second Canvas viewer URL: {error}"))
     })?;
     let config = viewer
         .query_pairs()
         .find_map(|(name, value)| (name == "js").then(|| value.into_owned()))
+        .or_else(|| {
+            EMBEDDED_CONFIG_RE
+                .captures(viewer_bytes)
+                .and_then(|captures| captures.name("config"))
+                .map(|config| String::from_utf8_lossy(config.as_bytes()).into_owned())
+        })
         .ok_or_else(|| {
-            DiscoveryError::Session("Second Canvas viewer URL has no js configuration".into())
+            DiscoveryError::Session("Second Canvas viewer has no JSON configuration".into())
         })?;
     let config = viewer.join(&config).map_err(|error| {
         DiscoveryError::Session(format!("invalid Second Canvas configuration URL: {error}"))
@@ -141,16 +184,16 @@ fn build_levels(
                 x: image_size.x.div_ceil(downscale),
                 y: image_size.y.div_ceil(downscale),
             };
-            let origin = Arc::clone(&origin);
-            let pattern = Arc::clone(&pattern);
-            let source = Grid::with_requests(
+            let validation_origin = Arc::clone(&origin);
+            let validation_pattern = Arc::clone(&pattern);
+            let validation = Grid::with_requests(
                 StableId::new(format!("second-canvas:{}:{level}", layer.id(0))),
                 level_size,
                 Vec2d::square(gigapixel.tile),
                 Vec2d::default(),
                 move |tile| {
                     Request::new(format!(
-                        "{origin}{pattern}{level}_{}_{}.jpg",
+                        "{validation_origin}{validation_pattern}{level}_{}_{}.jpg",
                         tile.coord.column, tile.coord.row
                     ))
                 },
@@ -158,11 +201,65 @@ fn build_levels(
             .map_err(|error| {
                 DiscoveryError::Session(format!("invalid Second Canvas grid: {error}"))
             })?;
+            // Second Canvas serves full-sized padded JPEGs for edge cells.
+            // Keep their decoded size and let the declared canvas crop padding
+            // instead of scaling edge pixels down in browser runtimes.
+            let source = Positioned::from_generator(
+                StableId::new(format!("second-canvas:{}:{level}", layer.id(0))),
+                Some(level_size),
+                SecondCanvasTiles {
+                    origin: Arc::clone(&origin),
+                    pattern: Arc::clone(&pattern),
+                    level,
+                    tile_size: gigapixel.tile,
+                    shape: validation.shape(),
+                    count: validation.count(),
+                },
+            );
             Ok(LevelDescriptor::new(source)
                 .with_scale_factor(Some(downscale))
                 .with_title(Some(format!("Second Canvas level {level}"))))
         })
         .collect()
+}
+
+#[derive(Clone, Debug)]
+struct SecondCanvasTiles {
+    origin: Arc<str>,
+    pattern: Arc<str>,
+    level: u32,
+    tile_size: u32,
+    shape: Vec2d,
+    count: u64,
+}
+
+impl crate::core::tile_plan::PositionedGenerator for SecondCanvasTiles {
+    fn count(&self) -> u64 {
+        self.count
+    }
+
+    fn tile(&self, ordinal: u64) -> Result<PositionedTile, TileSourceError> {
+        let column = u32::try_from(ordinal % u64::from(self.shape.x))
+            .map_err(|_| TileSourceError::ArithmeticOverflow)?;
+        let row = u32::try_from(ordinal / u64::from(self.shape.x))
+            .map_err(|_| TileSourceError::ArithmeticOverflow)?;
+        let destination = Vec2d {
+            x: column
+                .checked_mul(self.tile_size)
+                .ok_or(TileSourceError::ArithmeticOverflow)?,
+            y: row
+                .checked_mul(self.tile_size)
+                .ok_or(TileSourceError::ArithmeticOverflow)?,
+        };
+        Ok(PositionedTile {
+            request: Request::new(format!(
+                "{}{}{}_{}_{}.jpg",
+                self.origin, self.pattern, self.level, column, row
+            )),
+            destination,
+            processing: ProcessingRecipe::None,
+        })
+    }
 }
 
 #[derive(Deserialize)]
@@ -319,11 +416,11 @@ mod tests {
         let CatalogEntry::Ready(image) = &catalog.entries()[0] else {
             panic!("expected ready image");
         };
-        let TileSource::Grid(grid) = &image.levels.last().unwrap().source else {
-            panic!("expected grid");
+        let TileSource::Positioned(tiles) = &image.levels.last().unwrap().source else {
+            panic!("expected positioned tiles");
         };
-        let urls: Vec<_> = grid
-            .tiles_row_major()
+        let urls: Vec<_> = tiles
+            .tiles()
             .map(|tile| tile.unwrap().request.uri)
             .collect();
         assert_eq!(
@@ -334,16 +431,33 @@ mod tests {
             urls.last().unwrap(),
             "https://sc.example.test/gigapixel/modern/normal_3_2_1.jpg"
         );
+        assert_eq!(tiles.image_size(), Some(Vec2d { x: 1300, y: 900 }));
+        let last = tiles.tiles().last().unwrap().unwrap();
+        assert_eq!(last.destination, Vec2d { x: 1024, y: 512 });
+        assert_eq!(last.expected_size, None, "padded edge tiles are clipped");
     }
 
     #[test]
     fn viewer_js_parameter_resolves_against_the_viewer_page() {
         assert_eq!(
             viewer_config_uri(
-                "https://fixtures.test/web/index.html?js=metadata%2Fmodern.json&ua=test"
+                "https://fixtures.test/web/index.html?js=metadata%2Fmodern.json&ua=test",
+                b"<script src=\"scw.min.js\"></script>",
             )
             .unwrap(),
             "https://fixtures.test/web/metadata/modern.json"
+        );
+    }
+
+    #[test]
+    fn embedded_viewer_hash_resolves_against_the_viewer_page() {
+        assert_eq!(
+            viewer_config_uri(
+                "https://fixtures.test/web/gallery/metropolis_es.html",
+                br#"<script src="scv.min.js"></script><script>scv.load({ "hash":"metropolis_es.json" });</script>"#,
+            )
+            .unwrap(),
+            "https://fixtures.test/web/gallery/metropolis_es.json"
         );
     }
 }

--- a/crates/dezoomify-core/src/second_canvas/mod.rs
+++ b/crates/dezoomify-core/src/second_canvas/mod.rs
@@ -3,15 +3,19 @@
 use std::sync::Arc;
 
 use serde::{Deserialize, de::IntoDeserializer};
+use url::Url;
 
 use crate::Vec2d;
 use crate::core::{
-    CatalogEntry, DezoomerSpec, DiscoveryError, DiscoveryMatch, DiscoveryRoute, Grid, ImageCatalog,
-    ImageDescriptor, LevelDescriptor, Request, StableId,
+    CatalogEntry, DezoomerSpec, DiscoveryContext, DiscoveryError, DiscoveryMatch,
+    DiscoveryResource, DiscoveryRoute, DiscoveryStep, Grid, ImageCatalog, ImageDescriptor,
+    LevelDescriptor, Request, StableId,
 };
 
-const ROUTES: &[DiscoveryRoute] =
-    &[DiscoveryMatch::ContentPredicate(contains_gigapixel).extract(catalog)];
+const ROUTES: &[DiscoveryRoute] = &[
+    DiscoveryMatch::ContentPredicate(contains_gigapixel).extract(catalog),
+    DiscoveryMatch::ContentPredicate(contains_viewer_script).then(follow_viewer_config),
+];
 
 pub const SPEC: DezoomerSpec =
     DezoomerSpec::new("second_canvas", ROUTES).with_display_name("Second Canvas");
@@ -21,6 +25,41 @@ fn contains_gigapixel(bytes: &[u8]) -> bool {
         .ok()
         .and_then(|document| document.get("gigapixel").cloned())
         .is_some_and(|gigapixel| gigapixel.is_object())
+}
+
+fn contains_viewer_script(bytes: &[u8]) -> bool {
+    let page = String::from_utf8_lossy(bytes).to_ascii_lowercase();
+    page.contains("scw.min.js") || page.contains("scv.min.js")
+}
+
+fn follow_viewer_config(
+    _: &DiscoveryContext<'_>,
+    resource: DiscoveryResource<'_>,
+) -> Result<DiscoveryStep, DiscoveryError> {
+    Ok(DiscoveryStep::Follow(Request::new(viewer_config_uri(
+        resource.final_uri(),
+    )?)))
+}
+
+fn viewer_config_uri(viewer_uri: &str) -> Result<String, DiscoveryError> {
+    let viewer = Url::parse(viewer_uri).map_err(|error| {
+        DiscoveryError::Session(format!("invalid Second Canvas viewer URL: {error}"))
+    })?;
+    let config = viewer
+        .query_pairs()
+        .find_map(|(name, value)| (name == "js").then(|| value.into_owned()))
+        .ok_or_else(|| {
+            DiscoveryError::Session("Second Canvas viewer URL has no js configuration".into())
+        })?;
+    let config = viewer.join(&config).map_err(|error| {
+        DiscoveryError::Session(format!("invalid Second Canvas configuration URL: {error}"))
+    })?;
+    if !config.path().to_ascii_lowercase().ends_with(".json") {
+        return Err(DiscoveryError::Session(
+            "Second Canvas viewer js configuration is not JSON".into(),
+        ));
+    }
+    Ok(config.into())
 }
 
 fn catalog(_: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
@@ -294,6 +333,17 @@ mod tests {
         assert_eq!(
             urls.last().unwrap(),
             "https://sc.example.test/gigapixel/modern/normal_3_2_1.jpg"
+        );
+    }
+
+    #[test]
+    fn viewer_js_parameter_resolves_against_the_viewer_page() {
+        assert_eq!(
+            viewer_config_uri(
+                "https://fixtures.test/web/index.html?js=metadata%2Fmodern.json&ua=test"
+            )
+            .unwrap(),
+            "https://fixtures.test/web/metadata/modern.json"
         );
     }
 }

--- a/crates/dezoomify-core/src/second_canvas/mod.rs
+++ b/crates/dezoomify-core/src/second_canvas/mod.rs
@@ -1,0 +1,299 @@
+//! Pure discovery for Second Canvas (Madpixel) `gigapixel` JSON metadata.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, de::IntoDeserializer};
+
+use crate::Vec2d;
+use crate::core::{
+    CatalogEntry, DezoomerSpec, DiscoveryError, DiscoveryMatch, DiscoveryRoute, Grid, ImageCatalog,
+    ImageDescriptor, LevelDescriptor, Request, StableId,
+};
+
+const ROUTES: &[DiscoveryRoute] =
+    &[DiscoveryMatch::ContentPredicate(contains_gigapixel).extract(catalog)];
+
+pub const SPEC: DezoomerSpec =
+    DezoomerSpec::new("second_canvas", ROUTES).with_display_name("Second Canvas");
+
+fn contains_gigapixel(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()
+        .and_then(|document| document.get("gigapixel").cloned())
+        .is_some_and(|gigapixel| gigapixel.is_object())
+}
+
+fn catalog(_: &str, bytes: &[u8]) -> Result<ImageCatalog, DiscoveryError> {
+    let document: Document = serde_json::from_slice(bytes).map_err(|error| {
+        DiscoveryError::Session(format!("unable to parse Second Canvas metadata: {error}"))
+    })?;
+    let gigapixel = document.gigapixel;
+    if gigapixel.url.is_empty()
+        || gigapixel.size.w == 0
+        || gigapixel.size.h == 0
+        || gigapixel.tile == 0
+    {
+        return Err(DiscoveryError::Session(
+            "Second Canvas metadata must declare a URL and positive size and tile values".into(),
+        ));
+    }
+    let layers = gigapixel.layers()?;
+    let normal_level = layers
+        .iter()
+        .find(|layer| layer.is_normal())
+        .or_else(|| layers.first())
+        .map(|layer| layer.level)
+        .ok_or_else(|| {
+            DiscoveryError::Session("Second Canvas metadata has no image layers".into())
+        })?;
+
+    let entries = layers
+        .into_iter()
+        .enumerate()
+        .map(|(index, layer)| {
+            let image_size = layer_size(gigapixel.size, normal_level, layer.level)?;
+            let levels = build_levels(&gigapixel, &layer, image_size)?;
+            let layer_title = layer.title();
+            Ok(CatalogEntry::Ready(ImageDescriptor {
+                id: StableId::new(format!("second-canvas:{}", layer.id(index))),
+                title: document.title.clone().map(|title| {
+                    if layer.is_normal() {
+                        title
+                    } else {
+                        layer_title.map_or(title.clone(), |layer_title| {
+                            format!("{title} ({layer_title})")
+                        })
+                    }
+                }),
+                format: StableId::new("second_canvas"),
+                levels,
+                ..Default::default()
+            }))
+        })
+        .collect::<Result<Vec<_>, DiscoveryError>>()?;
+    ImageCatalog::new(entries)
+        .normalize()
+        .map_err(|error| DiscoveryError::Session(error.to_string()))
+}
+
+fn layer_size(size: Size, normal_level: u32, layer_level: u32) -> Result<Vec2d, DiscoveryError> {
+    let divisor = 1_u32
+        .checked_shl(normal_level.saturating_sub(layer_level))
+        .ok_or_else(|| DiscoveryError::Session("Second Canvas level is too large".into()))?;
+    Ok(Vec2d {
+        x: size.w.div_ceil(divisor),
+        y: size.h.div_ceil(divisor),
+    })
+}
+
+fn build_levels(
+    gigapixel: &Gigapixel,
+    layer: &Layer,
+    image_size: Vec2d,
+) -> Result<Vec<LevelDescriptor>, DiscoveryError> {
+    let origin: Arc<str> = gigapixel.url.clone().into();
+    let pattern: Arc<str> = layer.pattern.clone().into();
+    (0..=layer.level)
+        .map(|level| {
+            let downscale = 1_u32.checked_shl(layer.level - level).ok_or_else(|| {
+                DiscoveryError::Session("Second Canvas level is too large".into())
+            })?;
+            let level_size = Vec2d {
+                x: image_size.x.div_ceil(downscale),
+                y: image_size.y.div_ceil(downscale),
+            };
+            let origin = Arc::clone(&origin);
+            let pattern = Arc::clone(&pattern);
+            let source = Grid::with_requests(
+                StableId::new(format!("second-canvas:{}:{level}", layer.id(0))),
+                level_size,
+                Vec2d::square(gigapixel.tile),
+                Vec2d::default(),
+                move |tile| {
+                    Request::new(format!(
+                        "{origin}{pattern}{level}_{}_{}.jpg",
+                        tile.coord.column, tile.coord.row
+                    ))
+                },
+            )
+            .map_err(|error| {
+                DiscoveryError::Session(format!("invalid Second Canvas grid: {error}"))
+            })?;
+            Ok(LevelDescriptor::new(source)
+                .with_scale_factor(Some(downscale))
+                .with_title(Some(format!("Second Canvas level {level}"))))
+        })
+        .collect()
+}
+
+#[derive(Deserialize)]
+struct Document {
+    title: Option<String>,
+    gigapixel: Gigapixel,
+}
+
+#[derive(Deserialize)]
+struct Gigapixel {
+    url: String,
+    size: Size,
+    tile: u32,
+    #[serde(default)]
+    types: Vec<Layer>,
+    pattern: Option<String>,
+    #[serde(deserialize_with = "deserialize_optional_flexible_u32", default)]
+    level: Option<u32>,
+    ir: Option<Layer>,
+    rx: Option<Layer>,
+    uv: Option<Layer>,
+}
+
+impl Gigapixel {
+    fn layers(&self) -> Result<Vec<Layer>, DiscoveryError> {
+        if !self.types.is_empty() {
+            return Ok(self.types.clone());
+        }
+        let pattern = self.pattern.clone().ok_or_else(|| {
+            DiscoveryError::Session("legacy Second Canvas metadata has no normal pattern".into())
+        })?;
+        let level = self.level.ok_or_else(|| {
+            DiscoveryError::Session("legacy Second Canvas metadata has no normal level".into())
+        })?;
+        let mut layers = vec![Layer {
+            name: Some("Normal".into()),
+            kind: Some("normal".into()),
+            pattern,
+            level,
+        }];
+        for (kind, layer) in [("ir", &self.ir), ("rx", &self.rx), ("uv", &self.uv)] {
+            if let Some(layer) = layer {
+                let mut layer = layer.clone();
+                layer.kind.get_or_insert_with(|| kind.into());
+                layers.push(layer);
+            }
+        }
+        Ok(layers)
+    }
+}
+
+#[derive(Clone, Deserialize)]
+struct Layer {
+    name: Option<String>,
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    pattern: String,
+    #[serde(deserialize_with = "deserialize_flexible_u32")]
+    level: u32,
+}
+
+impl Layer {
+    fn is_normal(&self) -> bool {
+        self.kind
+            .as_deref()
+            .or(self.name.as_deref())
+            .is_some_and(|value| value.eq_ignore_ascii_case("normal"))
+    }
+
+    fn id(&self, fallback: usize) -> String {
+        self.kind
+            .as_deref()
+            .or(self.name.as_deref())
+            .map(str::to_ascii_lowercase)
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| fallback.to_string())
+    }
+
+    fn title(&self) -> Option<String> {
+        self.name.clone().or_else(|| self.kind.clone())
+    }
+}
+
+#[derive(Clone, Copy, Deserialize)]
+struct Size {
+    w: u32,
+    h: u32,
+}
+
+fn deserialize_flexible_u32<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Value {
+        Number(u32),
+        String(String),
+    }
+    match Value::deserialize(deserializer)? {
+        Value::Number(value) => Ok(value),
+        Value::String(value) => value.parse().map_err(serde::de::Error::custom),
+    }
+}
+
+fn deserialize_optional_flexible_u32<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<serde_json::Value>::deserialize(deserializer)?.map_or(Ok(None), |value| {
+        deserialize_flexible_u32(value.into_deserializer())
+            .map(Some)
+            .map_err(serde::de::Error::custom)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::TileSource;
+
+    fn fixture(name: &str) -> &'static [u8] {
+        match name {
+            "legacy" => include_bytes!(
+                "../../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy.json"
+            ),
+            "legacy-string" => include_bytes!(
+                "../../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy-string-level.json"
+            ),
+            "modern" => include_bytes!(
+                "../../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/modern.json"
+            ),
+            _ => panic!("unknown fixture"),
+        }
+    }
+
+    #[test]
+    fn parses_legacy_and_modern_layer_variants() {
+        let legacy = catalog("https://fixtures.test/legacy.json", fixture("legacy")).unwrap();
+        assert_eq!(legacy.len(), 4);
+        let legacy_string = catalog(
+            "https://fixtures.test/legacy-string.json",
+            fixture("legacy-string"),
+        )
+        .unwrap();
+        assert_eq!(legacy_string.len(), 2);
+        let modern = catalog("https://fixtures.test/modern.json", fixture("modern")).unwrap();
+        assert_eq!(modern.len(), 2);
+    }
+
+    #[test]
+    fn builds_zero_based_jpeg_tile_urls_at_each_level() {
+        let catalog = catalog("https://fixtures.test/modern.json", fixture("modern")).unwrap();
+        let CatalogEntry::Ready(image) = &catalog.entries()[0] else {
+            panic!("expected ready image");
+        };
+        let TileSource::Grid(grid) = &image.levels.last().unwrap().source else {
+            panic!("expected grid");
+        };
+        let urls: Vec<_> = grid
+            .tiles_row_major()
+            .map(|tile| tile.unwrap().request.uri)
+            .collect();
+        assert_eq!(
+            urls[0],
+            "https://sc.example.test/gigapixel/modern/normal_3_0_0.jpg"
+        );
+        assert_eq!(
+            urls.last().unwrap(),
+            "https://sc.example.test/gigapixel/modern/normal_3_2_1.jpg"
+        );
+    }
+}

--- a/crates/dezoomify-core/tests/parity.rs
+++ b/crates/dezoomify-core/tests/parity.rs
@@ -165,6 +165,29 @@ fn automatic_discovery_selects_every_ready_format() {
     assert_eq!(image.id.as_str(), "bulk:0");
 }
 
+#[test]
+fn second_canvas_viewer_page_follows_its_js_configuration() {
+    let viewer = "https://fixtures.test/second-canvas/web/index.html?js=metadata%2Fmodern.json";
+    let metadata = "https://fixtures.test/second-canvas/web/metadata/modern.json";
+    let image = ready_image(
+        discover(
+            viewer,
+            &[
+                (
+                    viewer,
+                    include_bytes!("../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/viewer.html"),
+                ),
+                (
+                    metadata,
+                    include_bytes!("../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/modern.json"),
+                ),
+            ],
+        )
+        .unwrap(),
+    );
+    assert_eq!(image.format.as_str(), "second_canvas");
+}
+
 fn grid(level: &LevelDescriptor) -> &Grid {
     match &level.source {
         TileSource::Grid(grid) => grid,

--- a/crates/dezoomify-core/tests/parity.rs
+++ b/crates/dezoomify-core/tests/parity.rs
@@ -101,6 +101,14 @@ fn automatic_discovery_selects_every_ready_format() {
             "krpano",
         ),
         (
+            "https://fixtures.test/second-canvas/modern.json",
+            &[ (
+                "https://fixtures.test/second-canvas/modern.json",
+                include_bytes!("../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/modern.json"),
+            ) ],
+            "second_canvas",
+        ),
+        (
             "https://fixtures.test/iip?FIF=/image.tif",
             &[ (
                 "https://fixtures.test/iip?FIF=/image.tif&OBJ=Max-size&OBJ=Tile-size&OBJ=Resolution-number",

--- a/crates/dezoomify-core/tests/parity.rs
+++ b/crates/dezoomify-core/tests/parity.rs
@@ -188,6 +188,34 @@ fn second_canvas_viewer_page_follows_its_js_configuration() {
     assert_eq!(image.format.as_str(), "second_canvas");
 }
 
+#[test]
+fn second_canvas_museum_page_follows_its_embedded_viewer_configuration() {
+    let page = "https://museum.example.test/collection/metropolis";
+    let viewer = "https://sc.example.test.s3.amazonaws.com/web/gallery/metropolis_es.html";
+    let metadata = "https://sc.example.test.s3.amazonaws.com/web/gallery/metropolis_es.json";
+    let image = ready_image(
+        discover(
+            page,
+            &[
+                (
+                    page,
+                    include_bytes!("../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/museum-page.html"),
+                ),
+                (
+                    viewer,
+                    include_bytes!("../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/embedded-viewer.html"),
+                ),
+                (
+                    metadata,
+                    include_bytes!("../../../testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/modern.json"),
+                ),
+            ],
+        )
+        .unwrap(),
+    );
+    assert_eq!(image.format.as_str(), "second_canvas");
+}
+
 fn grid(level: &LevelDescriptor) -> &Grid {
     match &level.source {
         TileSource::Grid(grid) => grid,

--- a/crates/xtask/src/live.rs
+++ b/crates/xtask/src/live.rs
@@ -65,12 +65,12 @@ const TARGETS: &[LiveTarget] = &[
         headers: &[],
         accept_invalid_certs: false,
     },
-    // Nationalmuseum links to this immutable public configuration from its
-    // Second Canvas collection page. It exercises the version-2 `types`
-    // schema without relying on a viewer page or an institution session.
+    // Nationalmuseum links to this public Second Canvas viewer. Its `js`
+    // parameter identifies the immutable version-2 configuration, exercising
+    // both viewer-page auto discovery and the `types` schema.
     LiveTarget {
         name: "second_canvas_nationalmuseum",
-        url: "https://sc52c295l2e0u257236675112f3025a8b.s3.amazonaws.com/web/52w981s7g6u181258638003c0d64ad1/a52w35039o216d250100915f780a519_en.json",
+        url: "https://sc52c295l2e0u257236675112f3025a8b.s3.amazonaws.com/web/index.html?js=52w981s7g6u181258638003c0d64ad1%2Fa52w35039o216d250100915f780a519_en.json",
         headers: &[],
         accept_invalid_certs: false,
     },

--- a/crates/xtask/src/live.rs
+++ b/crates/xtask/src/live.rs
@@ -65,6 +65,15 @@ const TARGETS: &[LiveTarget] = &[
         headers: &[],
         accept_invalid_certs: false,
     },
+    // Nationalmuseum links to this immutable public configuration from its
+    // Second Canvas collection page. It exercises the version-2 `types`
+    // schema without relying on a viewer page or an institution session.
+    LiveTarget {
+        name: "second_canvas_nationalmuseum",
+        url: "https://sc52c295l2e0u257236675112f3025a8b.s3.amazonaws.com/web/52w981s7g6u181258638003c0d64ad1/a52w35039o216d250100915f780a519_en.json",
+        headers: &[],
+        accept_invalid_certs: false,
+    },
     LiveTarget {
         name: "iiif",
         url: "https://i.micr.io/fhXoU/info.json",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -71,6 +71,7 @@ formats](user/supported-formats.md) for what to paste per format.
 |---|---|---|---|---|
 | Zoomify | Yes | Yes | Yes | Yes |
 | Deep Zoom (Seadragon) | Yes | Yes | Yes | Yes |
+| Second Canvas | Yes | Yes | Yes | Yes |
 | IIIF | Yes | Yes | Yes | Yes |
 | Arts and Culture | Yes | Yes | Yes | Yes |
 | IIPImage | Yes | Yes | Yes | Yes |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -54,8 +54,8 @@ stays listed in the `docs/compatibility.md` dashboard, never tolerated as a
 silent failure. Removal from `crates/xtask/src/live.rs` happens only when the
 site is gone for good or the format is redesigned, with the reason in the
 commit message. `cargo xtask test live --dry-run --fixtures` validates the
-34-target list plus quarantine with no network; `cargo xtask test live
---public --quarantine --report-only` is the nightly advisory full-34 run that
+36-target list plus quarantine with no network; `cargo xtask test live
+--public --quarantine --report-only` is the nightly advisory full-36 run that
 never blocks pull requests.
 
 Focused targets are:

--- a/docs/user/supported-formats.md
+++ b/docs/user/supported-formats.md
@@ -17,7 +17,7 @@ for how to find that file.
 |---|---|---|
 | Zoomify | Many museums and libraries | The viewer page, `ImageProperties.xml`, or any tile address |
 | Deep Zoom (Seadragon) | Microsoft-style viewers, many digital libraries | The viewer page or the `.dzi` file |
-| Second Canvas | Madpixel museum viewers | The viewer page or its `web/..._<language>.json` configuration file |
+| Second Canvas | Madpixel museum viewers | A museum page that embeds the viewer, the viewer page, or its `web/..._<language>.json` configuration file |
 | IIIF | Widely used by national and university libraries | A viewer page, an `info.json` file, or a presentation manifest for whole books |
 | Arts & Culture | Google Arts & Culture | The artwork page |
 | IIPImage | Image servers recognizable by `FIF=` in addresses | Any address containing `FIF=` |

--- a/docs/user/supported-formats.md
+++ b/docs/user/supported-formats.md
@@ -17,6 +17,7 @@ for how to find that file.
 |---|---|---|
 | Zoomify | Many museums and libraries | The viewer page, `ImageProperties.xml`, or any tile address |
 | Deep Zoom (Seadragon) | Microsoft-style viewers, many digital libraries | The viewer page or the `.dzi` file |
+| Second Canvas | Madpixel museum viewers | The viewer's `web/..._<language>.json` configuration file |
 | IIIF | Widely used by national and university libraries | A viewer page, an `info.json` file, or a presentation manifest for whole books |
 | Arts & Culture | Google Arts & Culture | The artwork page |
 | IIPImage | Image servers recognizable by `FIF=` in addresses | Any address containing `FIF=` |

--- a/docs/user/supported-formats.md
+++ b/docs/user/supported-formats.md
@@ -17,7 +17,7 @@ for how to find that file.
 |---|---|---|
 | Zoomify | Many museums and libraries | The viewer page, `ImageProperties.xml`, or any tile address |
 | Deep Zoom (Seadragon) | Microsoft-style viewers, many digital libraries | The viewer page or the `.dzi` file |
-| Second Canvas | Madpixel museum viewers | The viewer's `web/..._<language>.json` configuration file |
+| Second Canvas | Madpixel museum viewers | The viewer page or its `web/..._<language>.json` configuration file |
 | IIIF | Widely used by national and university libraries | A viewer page, an `info.json` file, or a presentation manifest for whole books |
 | Arts & Culture | Google Arts & Culture | The artwork page |
 | IIPImage | Image servers recognizable by `FIF=` in addresses | Any address containing `FIF=` |

--- a/testdata/scenarios/manifest.json
+++ b/testdata/scenarios/manifest.json
@@ -2065,6 +2065,18 @@
       "source_snapshot": "a304e43"
     },
     {
+      "content_type": "text/html",
+      "id": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/embedded-viewer.html",
+      "license_provenance": "local test fixture (synthetic Second Canvas viewer)",
+      "path": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/embedded-viewer.html",
+      "sensitive": false,
+      "served_urls": [],
+      "sha256": "887f46c5743c9fb0929cd3798738a9fc8d76c2e6a5696c3ade8d7e474396a911",
+      "size": 171,
+      "source_path": "Second Canvas embedded viewer schema documented in issue #808",
+      "source_snapshot": "2026-09-11"
+    },
+    {
       "content_type": "application/json",
       "id": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy-string-level.json",
       "license_provenance": "local test fixture (synthetic Second Canvas metadata)",
@@ -2086,6 +2098,18 @@
       "sha256": "ef51de815a72e836e23b0761266e166fc20943b7b4ba1c7f2d96c946bf79c941",
       "size": 374,
       "source_path": "Second Canvas legacy schema documented in issue #808",
+      "source_snapshot": "2026-09-11"
+    },
+    {
+      "content_type": "text/html",
+      "id": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/museum-page.html",
+      "license_provenance": "local test fixture (synthetic Second Canvas embed page)",
+      "path": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/museum-page.html",
+      "sensitive": false,
+      "served_urls": [],
+      "sha256": "dcf67a68ea807916332af8cbc84afbf1a0739785e7e0f2f309c64a8f2789eead",
+      "size": 138,
+      "source_path": "Second Canvas museum iframe flow reported on PR #1031",
       "source_snapshot": "2026-09-11"
     },
     {

--- a/testdata/scenarios/manifest.json
+++ b/testdata/scenarios/manifest.json
@@ -2101,6 +2101,18 @@
       "source_snapshot": "2026-09-11"
     },
     {
+      "content_type": "text/html",
+      "id": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/viewer.html",
+      "license_provenance": "local test fixture (synthetic Second Canvas viewer)",
+      "path": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/viewer.html",
+      "sensitive": false,
+      "served_urls": [],
+      "sha256": "fc0f8bfb038a92f87ae74ba11588451b76332d9b43c7fda7224fa2aeae25ae2f",
+      "size": 135,
+      "source_path": "Second Canvas legacy viewer schema documented in issue #808",
+      "source_snapshot": "2026-09-11"
+    },
+    {
       "content_type": "image/png",
       "id": "rs-core/formats/payloads/root-testdata/deepzoom/expected_result.png",
       "license_provenance": "GPL-3.0-only (Rust source)",

--- a/testdata/scenarios/manifest.json
+++ b/testdata/scenarios/manifest.json
@@ -2065,6 +2065,42 @@
       "source_snapshot": "a304e43"
     },
     {
+      "content_type": "application/json",
+      "id": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy-string-level.json",
+      "license_provenance": "local test fixture (synthetic Second Canvas metadata)",
+      "path": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy-string-level.json",
+      "sensitive": false,
+      "served_urls": [],
+      "sha256": "51492a25845b963cf4b73fca183b673ef013045d4c69f1a9001b5b89b314c002",
+      "size": 330,
+      "source_path": "Second Canvas legacy schema documented in issue #808",
+      "source_snapshot": "2026-09-11"
+    },
+    {
+      "content_type": "application/json",
+      "id": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy.json",
+      "license_provenance": "local test fixture (synthetic Second Canvas metadata)",
+      "path": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy.json",
+      "sensitive": false,
+      "served_urls": [],
+      "sha256": "ef51de815a72e836e23b0761266e166fc20943b7b4ba1c7f2d96c946bf79c941",
+      "size": 374,
+      "source_path": "Second Canvas legacy schema documented in issue #808",
+      "source_snapshot": "2026-09-11"
+    },
+    {
+      "content_type": "application/json",
+      "id": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/modern.json",
+      "license_provenance": "local test fixture (synthetic Second Canvas metadata)",
+      "path": "rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/modern.json",
+      "sensitive": false,
+      "served_urls": [],
+      "sha256": "c6b0ed78f24b0c70988f63b67602135b1ade88e7d950796ab081acd36c70474f",
+      "size": 415,
+      "source_path": "Second Canvas modern schema documented in issue #808",
+      "source_snapshot": "2026-09-11"
+    },
+    {
       "content_type": "image/png",
       "id": "rs-core/formats/payloads/root-testdata/deepzoom/expected_result.png",
       "license_provenance": "GPL-3.0-only (Rust source)",

--- a/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/embedded-viewer.html
+++ b/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/embedded-viewer.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html><head><script src="https://secondcanvas.example.test/scv.min.js"></script><script>scv.load({ "hash": "metropolis_es.json" });</script></head></html>

--- a/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy-string-level.json
+++ b/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy-string-level.json
@@ -1,0 +1,12 @@
+{
+  "title": "Legacy string-level artwork",
+  "version": 1,
+  "gigapixel": {
+    "url": "https://sc.example.test/gigapixel/legacy-string/",
+    "pattern": "legacy_string_",
+    "level": "2",
+    "size": { "w": 1024, "h": 768 },
+    "tile": 512,
+    "ir": { "name": "Infrared", "pattern": "legacy_string_IR_", "level": "2" }
+  }
+}

--- a/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy.json
+++ b/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/legacy.json
@@ -1,0 +1,13 @@
+{
+  "title": "Legacy multi-layer artwork",
+  "gigapixel": {
+    "url": "https://sc.example.test/gigapixel/legacy/",
+    "pattern": "legacy_",
+    "level": 3,
+    "size": { "w": 1300, "h": 900 },
+    "tile": 512,
+    "ir": { "pattern": "legacy_IR_", "level": "2" },
+    "rx": { "pattern": "legacy_RX_", "level": 3 },
+    "uv": { "pattern": "legacy_UV_", "level": "1" }
+  }
+}

--- a/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/modern.json
+++ b/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/modern.json
@@ -1,0 +1,14 @@
+{
+  "title": "Modern multi-layer artwork",
+  "version": 2,
+  "gigapixel": {
+    "url": "https://sc.example.test/gigapixel/modern/",
+    "types": [
+      { "name": "Normal", "type": "normal", "pattern": "normal_", "level": "3" },
+      { "name": "Infrared", "type": "ir", "pattern": "normal_IR_", "level": 2 }
+    ],
+    "size": { "w": 1300, "h": 900 },
+    "mask": { "w": 162.5, "h": 112.5 },
+    "tile": 512
+  }
+}

--- a/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/museum-page.html
+++ b/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/museum-page.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html><body><iframe src="https://sc.example.test.s3.amazonaws.com/web/gallery/metropolis_es.html"></iframe></body></html>

--- a/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/viewer.html
+++ b/testdata/scenarios/rs-core/formats/payloads/dezoomify-core/testdata/second_canvas/viewer.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html>
+  <head><title>Second Canvas viewer</title></head>
+  <body><script src="js/scw.min.js"></script></body>
+</html>


### PR DESCRIPTION
Closes #808.\n\nAdds pure-core Second Canvas discovery for direct configuration URLs, viewer pages, and museum pages that embed a Second Canvas viewer. Viewer-page discovery precisely identifies the Second Canvas viewer script and follows either its js configuration reference or embedded scv.load hash. The parser supports legacy flat descriptors (including numeric and string levels) plus modern version-2 types arrays, including multi-layer catalogs.\n\nSecond Canvas padded edge JPEGs are emitted as positioned tiles within the declared canvas, so browser runtimes crop padding rather than scale edge pixels and emit mismatch warnings.\n\nAdds deterministic fixtures for legacy variants, modern configuration, viewer-page discovery, and museum-page iframe discovery. Also adds a low-volume Nationalmuseum viewer-page live canary, exercising the full HTML-page-to-configuration flow against the modern schema.\n\nValidation:\n- cargo xtask check\n- cargo xtask test all\n- cargo xtask ci local\n- cargo xtask test wasm\n- cargo xtask test browser --build-only\n- cargo xtask fixtures verify\n- local CLI: https://www.museothyssen.org/conectathyssen/gigathyssen/metropolis passed as second_canvas (929x920, 4 tiles)\n- cargo xtask test live --dry-run --fixtures (36 targets)\n- cargo xtask test live --public --site second_canvas_nationalmuseum (passed: second_canvas, 1016x826, 4 tiles)