### PR TITLE
fix(web): fit preview images in both dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
           <span id="preview-zoom-label" class="dz-preview-zoom-label" aria-live="polite">100%</span>
           <button type="button" class="dz-btn-secondary" id="preview-zoom-in" aria-label="Zoom in">+</button>
           <button type="button" class="dz-btn-secondary" id="preview-zoom-100" aria-label="Reset zoom to 100 percent">100%</button>
-          <button type="button" class="dz-btn-secondary" id="preview-zoom-reset" aria-label="Reset preview pan and zoom">Reset</button>
+          <button type="button" class="dz-btn-secondary" id="preview-zoom-fit" aria-label="Fit image inside preview">Fit</button>
         </div>
         <div id="canvas-stack" class="dz-canvas-stack">
           <canvas id="rendering-canvas" width="0" height="0"></canvas>

--- a/packages/browser-runtime/src/preview.ts
+++ b/packages/browser-runtime/src/preview.ts
@@ -48,14 +48,19 @@ export interface PreviewControls {
   initControls(doc: PreviewDocumentLike): void;
 }
 
-export function clampPreviewScale(scale: unknown): number {
+function clampScale(scale: unknown, minimum: number): number {
   const value = typeof scale === "number" ? scale : Number(scale);
   if (!Number.isFinite(value)) return 1;
-  return Math.min(PREVIEW_MAX_SCALE, Math.max(PREVIEW_MIN_SCALE, value));
+  return Math.min(PREVIEW_MAX_SCALE, Math.max(minimum, value));
+}
+
+export function clampPreviewScale(scale: unknown): number {
+  return clampScale(scale, PREVIEW_MIN_SCALE);
 }
 
 export function createPreviewControls(): PreviewControls {
   let transform: PreviewTransform = { scale: 1, tx: 0, ty: 0 };
+  let minimumScale = PREVIEW_MIN_SCALE;
   let wired = false;
 
   function getTransform(): PreviewTransform {
@@ -112,18 +117,21 @@ export function createPreviewControls(): PreviewControls {
   function fitScale(doc?: PreviewDocumentLike | null): number {
     const size = geometry(doc);
     if (!size) return 1;
-    return clampPreviewScale(Math.min(1, size.viewportWidth / size.width, size.viewportHeight / size.height));
+    // Fit may need to go below the normal zoom-out limit for tall images.
+    return Math.min(1, size.viewportWidth / size.width, size.viewportHeight / size.height);
   }
 
   function resetTransform(doc?: PreviewDocumentLike | null): PreviewTransform {
-    transform = { scale: fitScale(doc), tx: 0, ty: 0 };
+    const scale = fitScale(doc);
+    minimumScale = Math.min(PREVIEW_MIN_SCALE, scale);
+    transform = { scale, tx: 0, ty: 0 };
     applyTransform(doc);
     return getTransform();
   }
 
   function zoomBy(factor: unknown, doc?: PreviewDocumentLike | null): PreviewTransform {
     const value = typeof factor === "number" ? factor : Number(factor);
-    const next = clampPreviewScale(transform.scale * (Number.isFinite(value) ? value : 1));
+    const next = clampScale(transform.scale * (Number.isFinite(value) ? value : 1), minimumScale);
     transform = { ...transform, scale: next };
     clampTranslation(doc);
     applyTransform(doc);
@@ -131,6 +139,7 @@ export function createPreviewControls(): PreviewControls {
   }
 
   function setScale(scale: unknown, doc?: PreviewDocumentLike | null): PreviewTransform {
+    minimumScale = PREVIEW_MIN_SCALE;
     transform = { ...transform, scale: clampPreviewScale(scale) };
     clampTranslation(doc);
     applyTransform(doc);
@@ -155,7 +164,7 @@ export function createPreviewControls(): PreviewControls {
 
       doc.getElementById("preview-zoom-in")?.addEventListener("click", () => zoomBy(PREVIEW_ZOOM_STEP, doc));
       doc.getElementById("preview-zoom-out")?.addEventListener("click", () => zoomBy(1 / PREVIEW_ZOOM_STEP, doc));
-      doc.getElementById("preview-zoom-reset")?.addEventListener("click", () => resetTransform(doc));
+      doc.getElementById("preview-zoom-fit")?.addEventListener("click", () => resetTransform(doc));
       doc.getElementById("preview-zoom-100")?.addEventListener("click", () => setScale(1, doc));
 
       // Wheel zoom (ctrl/pinch friendly): scale around the viewport center via

--- a/packages/browser-runtime/src/preview.ts
+++ b/packages/browser-runtime/src/preview.ts
@@ -7,8 +7,6 @@
 // display-only path stays display-only; preview never promises a clean save.
 // The host document is injected so node tests drive the transform math
 // without a DOM. Keep erasable-syntax-only for the browser `.js` mirrors.
-export const PREVIEW_MIN_SCALE = 0.1;
-export const PREVIEW_MAX_SCALE = 8;
 export const PREVIEW_ZOOM_STEP = 1.25;
 const PREVIEW_WHEEL_STEP_PIXELS = 100;
 
@@ -48,19 +46,8 @@ export interface PreviewControls {
   initControls(doc: PreviewDocumentLike): void;
 }
 
-function clampScale(scale: unknown, minimum: number): number {
-  const value = typeof scale === "number" ? scale : Number(scale);
-  if (!Number.isFinite(value)) return 1;
-  return Math.min(PREVIEW_MAX_SCALE, Math.max(minimum, value));
-}
-
-export function clampPreviewScale(scale: unknown): number {
-  return clampScale(scale, PREVIEW_MIN_SCALE);
-}
-
 export function createPreviewControls(): PreviewControls {
   let transform: PreviewTransform = { scale: 1, tx: 0, ty: 0 };
-  let minimumScale = PREVIEW_MIN_SCALE;
   let wired = false;
 
   function getTransform(): PreviewTransform {
@@ -117,21 +104,18 @@ export function createPreviewControls(): PreviewControls {
   function fitScale(doc?: PreviewDocumentLike | null): number {
     const size = geometry(doc);
     if (!size) return 1;
-    // Fit may need to go below the normal zoom-out limit for tall images.
     return Math.min(1, size.viewportWidth / size.width, size.viewportHeight / size.height);
   }
 
   function resetTransform(doc?: PreviewDocumentLike | null): PreviewTransform {
-    const scale = fitScale(doc);
-    minimumScale = Math.min(PREVIEW_MIN_SCALE, scale);
-    transform = { scale, tx: 0, ty: 0 };
+    transform = { scale: fitScale(doc), tx: 0, ty: 0 };
     applyTransform(doc);
     return getTransform();
   }
 
   function zoomBy(factor: unknown, doc?: PreviewDocumentLike | null): PreviewTransform {
     const value = typeof factor === "number" ? factor : Number(factor);
-    const next = clampScale(transform.scale * (Number.isFinite(value) ? value : 1), minimumScale);
+    const next = Math.max(fitScale(doc), Math.min(1, transform.scale * (Number.isFinite(value) ? value : 1)));
     transform = { ...transform, scale: next };
     clampTranslation(doc);
     applyTransform(doc);
@@ -139,8 +123,9 @@ export function createPreviewControls(): PreviewControls {
   }
 
   function setScale(scale: unknown, doc?: PreviewDocumentLike | null): PreviewTransform {
-    minimumScale = PREVIEW_MIN_SCALE;
-    transform = { ...transform, scale: clampPreviewScale(scale) };
+    const value = typeof scale === "number" ? scale : Number(scale);
+    const next = Number.isFinite(value) ? Math.max(fitScale(doc), Math.min(1, value)) : 1;
+    transform = { ...transform, scale: next };
     clampTranslation(doc);
     applyTransform(doc);
     return getTransform();

--- a/packages/browser-runtime/test/preview-runtime.test.mjs
+++ b/packages/browser-runtime/test/preview-runtime.test.mjs
@@ -27,7 +27,7 @@ function doc() {
     "rendering-canvas": element({ width: 1600, height: 1200 }),
     "preview-zoom-in": element(),
     "preview-zoom-out": element(),
-    "preview-zoom-reset": element(),
+    "preview-zoom-fit": element(),
     "preview-zoom-100": element(),
     "preview-zoom-label": element(),
     "preview-controls": element(),
@@ -46,7 +46,7 @@ test("preview scale clamps to the tainted-safe transform range", () => {
   assert.equal(clampPreviewScale("bad"), 1);
 });
 
-test("zoom and reset apply transform-only styles", () => {
+test("zoom and fit apply transform-only styles", () => {
   const d = doc();
   const preview = createPreviewControls();
   preview.initControls(d);
@@ -57,6 +57,17 @@ test("zoom and reset apply transform-only styles", () => {
   preview.resetTransform(d);
   assert.deepEqual(preview.getTransform(), { scale: 0.5, tx: 0, ty: 0 });
   assert.match(canvas.style.transform, /scale\(0.5\)/);
+});
+
+test("fit keeps tall images inside the frame below the manual zoom limit", () => {
+  const d = doc();
+  d.ids["rendering-canvas"].width = 2000;
+  d.ids["rendering-canvas"].height = 20000;
+  const preview = createPreviewControls();
+  preview.initControls(d);
+  d.ids["preview-zoom-fit"].fire("click");
+  assert.deepEqual(preview.getTransform(), { scale: 0.03, tx: 0, ty: 0 });
+  assert.equal(d.ids["preview-zoom-label"].textContent, "3%");
 });
 
 test("controls wire buttons, wheel, and bounded drag without pixel reads", () => {
@@ -78,7 +89,7 @@ test("controls wire buttons, wheel, and bounded drag without pixel reads", () =>
   assert.equal(preview.getTransform().tx, 0);
   assert.equal(preview.getTransform().ty, 0);
   assert.equal(stopped, true);
-  d.ids["preview-zoom-reset"].fire("click");
+  d.ids["preview-zoom-fit"].fire("click");
   d.ids["preview-zoom-100"].fire("click");
   canvas.fire("pointerdown", { clientX: 10, clientY: 20, pointerId: 1 });
   canvas.fire("pointermove", { clientX: 1010, clientY: 1020 });
@@ -86,7 +97,7 @@ test("controls wire buttons, wheel, and bounded drag without pixel reads", () =>
   const moved = preview.getTransform();
   assert.equal(moved.tx, 400);
   assert.equal(moved.ty, 300);
-  d.ids["preview-zoom-reset"].fire("click");
+  d.ids["preview-zoom-fit"].fire("click");
   assert.deepEqual(preview.getTransform(), { scale: 0.5, tx: 0, ty: 0 });
   d.ids["preview-zoom-100"].fire("click");
   assert.equal(preview.getTransform().scale, 1);

--- a/packages/browser-runtime/test/preview-runtime.test.mjs
+++ b/packages/browser-runtime/test/preview-runtime.test.mjs
@@ -1,10 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
-  PREVIEW_MAX_SCALE,
-  PREVIEW_MIN_SCALE,
   PREVIEW_ZOOM_STEP,
-  clampPreviewScale,
   createPreviewControls,
   setCanvasVisible,
 } from "../src/preview.ts";
@@ -35,15 +32,8 @@ function doc() {
   return { ids, getElementById: (id) => ids[id] ?? null };
 }
 
-test("preview scale clamps to the tainted-safe transform range", () => {
-  assert.equal(PREVIEW_MIN_SCALE, 0.1);
-  assert.equal(PREVIEW_MAX_SCALE, 8);
+test("preview zoom uses the configured step", () => {
   assert.equal(PREVIEW_ZOOM_STEP, 1.25);
-  assert.equal(clampPreviewScale(1), 1);
-  assert.equal(clampPreviewScale(0), PREVIEW_MIN_SCALE);
-  assert.equal(clampPreviewScale(100), PREVIEW_MAX_SCALE);
-  assert.equal(clampPreviewScale(NaN), 1);
-  assert.equal(clampPreviewScale("bad"), 1);
 });
 
 test("zoom and fit apply transform-only styles", () => {
@@ -59,15 +49,18 @@ test("zoom and fit apply transform-only styles", () => {
   assert.match(canvas.style.transform, /scale\(0.5\)/);
 });
 
-test("fit keeps tall images inside the frame below the manual zoom limit", () => {
+test("zoom stays between fit and the image's natural scale", () => {
   const d = doc();
   d.ids["rendering-canvas"].width = 2000;
   d.ids["rendering-canvas"].height = 20000;
   const preview = createPreviewControls();
   preview.initControls(d);
-  d.ids["preview-zoom-fit"].fire("click");
   assert.deepEqual(preview.getTransform(), { scale: 0.03, tx: 0, ty: 0 });
   assert.equal(d.ids["preview-zoom-label"].textContent, "3%");
+  preview.zoomBy(100, d);
+  assert.equal(preview.getTransform().scale, 1);
+  preview.zoomBy(0.01, d);
+  assert.equal(preview.getTransform().scale, 0.03);
 });
 
 test("controls wire buttons, wheel, and bounded drag without pixel reads", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,24 +60,16 @@ import {
   createPreviewControls,
 } from "../packages/browser-runtime/src/preview.ts";
 import {
-  PREVIEW_MAX_SCALE,
-  PREVIEW_MIN_SCALE,
   PREVIEW_ZOOM_STEP,
-  clampPreviewScale,
 } from "../packages/browser-runtime/src/preview.ts";
 
-// Re-export the shared browser limits plus the preview transform helpers for
-// existing website test imports (`test/pick-level.test.mjs` and
-// `test/preview.test.mjs` import from `src/main.ts`).
+// Re-export the shared browser limits for existing website test imports.
 export {
   BROWSER_MAX_CANVAS_AREA,
   BROWSER_MAX_CANVAS_SIDE,
   BROWSER_MAX_PLAN_TILES,
   desktopHandoffLink,
-  PREVIEW_MAX_SCALE,
-  PREVIEW_MIN_SCALE,
   PREVIEW_ZOOM_STEP,
-  clampPreviewScale,
 };
 
 const preview = createPreviewControls();

--- a/test/preview.test.mjs
+++ b/test/preview.test.mjs
@@ -3,25 +3,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  PREVIEW_MIN_SCALE,
-  PREVIEW_MAX_SCALE,
-  PREVIEW_ZOOM_STEP,
-  clampPreviewScale,
-} from "../src/main.ts";
 
 const rootDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
-
-test("preview scale clamps to the tainted-safe transform range", () => {
-  assert.equal(PREVIEW_MIN_SCALE, 0.1);
-  assert.equal(PREVIEW_MAX_SCALE, 8);
-  assert.equal(PREVIEW_ZOOM_STEP, 1.25);
-  assert.equal(clampPreviewScale(1), 1);
-  assert.equal(clampPreviewScale(0), PREVIEW_MIN_SCALE);
-  assert.equal(clampPreviewScale(100), PREVIEW_MAX_SCALE);
-  assert.equal(clampPreviewScale(NaN), 1);
-  assert.equal(clampPreviewScale("bad"), 1);
-});
 
 test("website preview wires wheel, drag, and buttons without pixel reads", () => {
   // Todo 2.2: the preview lives in packages/browser-runtime/src/preview.ts;

--- a/test/preview.test.mjs
+++ b/test/preview.test.mjs
@@ -37,7 +37,7 @@ test("website preview wires wheel, drag, and buttons without pixel reads", () =>
   assert.ok(block.includes("pointerdown"), "drag pan wired");
   assert.ok(block.includes("preview-zoom-in"), "zoom-in button wired");
   assert.ok(block.includes("preview-zoom-out"), "zoom-out button wired");
-  assert.ok(block.includes("preview-zoom-reset"), "reset button wired");
+  assert.ok(block.includes("preview-zoom-fit"), "fit button wired");
   assert.ok(block.includes("preview-zoom-100"), "100% button wired");
   assert.ok(block.includes("style.transform"), "transform scale/translate applied");
   assert.ok(!block.includes("getImageData("), "preview never reads pixels (tainted-safe)");
@@ -47,9 +47,10 @@ test("website preview wires wheel, drag, and buttons without pixel reads", () =>
 
 test("preview controls exist in the page and theme", () => {
   const html = fs.readFileSync(path.join(rootDir, "index.html"), "utf8");
-  for (const id of ["preview-controls", "preview-zoom-in", "preview-zoom-out", "preview-zoom-100", "preview-zoom-reset", "preview-zoom-label"]) {
+  for (const id of ["preview-controls", "preview-zoom-in", "preview-zoom-out", "preview-zoom-100", "preview-zoom-fit", "preview-zoom-label"]) {
     assert.ok(html.includes(`id="${id}"`), `index.html missing #${id}`);
   }
+  assert.ok(html.includes(">Fit</button>"), "preview fit control is labelled Fit");
   const css = fs.readFileSync(path.join(rootDir, "packages/shared-ui/src/styles/theme.css"), "utf8");
   assert.ok(css.includes(".dz-preview-controls"), "theme styles the preview toolbar");
   assert.ok(css.includes("overflow: hidden"), "preview frame does not natively scroll with zoom");


### PR DESCRIPTION
## Summary
- Rename the preview reset control to `Fit`.
- Fit images against both frame dimensions.
- Let zoom range dynamically from the current fit scale to the image's natural scale, with no hardcoded minimum or maximum.
- Add regression coverage for tall images and dynamic zoom bounds.

## Tests
- `node --test packages/browser-runtime/test/preview-runtime.test.mjs test/preview.test.mjs`
- `cargo xtask test browser`
- `./node_modules/.bin/tsc --noEmit`
- `cargo xtask ci check`